### PR TITLE
TimeoutException should inherit from j.u.c.TimeoutException

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/TimeoutException.scala
+++ b/util-core/src/main/scala/com/twitter/util/TimeoutException.scala
@@ -1,3 +1,7 @@
 package com.twitter.util
 
-class TimeoutException(message: String) extends Exception(message)
+import java.util.concurrent.{TimeoutException => JUCTimeoutException}
+
+// Now that this is inherits from the usual TimeoutException, we can move to
+// j.u.c.TimeoutException during our next API break.
+class TimeoutException(message: String) extends JUCTimeoutException(message)


### PR DESCRIPTION
There is no difference and its existence is, so far, unexplained to me. We can move off of it and back to j.u.c.TimeoutException in our next API break (hopefully, a scheduled one).
