### PR TITLE
scaladoc mis-pluralization fixes.

### DIFF
--- a/util-core/src/main/scala/com/twitter/concurrent/Offer.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Offer.scala
@@ -317,7 +317,7 @@ trait Offer[+T] { self =>
    * Synchronize this offer.  This activates this offer and attempts
    * to perform the communication specified.
    *
-   * @returns A {{Future}} containing the communicated value.
+   * @return A {{Future}} containing the communicated value.
    */
   def apply(): Future[T] = {
     // We sort the objects here according to their identity.  In this

--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -205,7 +205,7 @@ class Eval(target: Option[File]) {
 
   /**
    * Check if code is Eval-able.
-   * @throw CompilerException if not Eval-able.
+   * @throws CompilerException if not Eval-able.
    */
   def check(code: String) {
     val id = uniqueId(sourceForString(code).code)
@@ -216,7 +216,7 @@ class Eval(target: Option[File]) {
 
   /**
    * Check if files are Eval-able.
-   * @throw CompilerException if not Eval-able.
+   * @throws CompilerException if not Eval-able.
    */
   def check(files: File*) {
     val code = files.map { scala.io.Source.fromFile(_).mkString }.mkString("\n")
@@ -225,7 +225,7 @@ class Eval(target: Option[File]) {
 
   /**
    * Check if stream is Eval-able.
-   * @throw CompilerException if not Eval-able.
+   * @throws CompilerException if not Eval-able.
    */
   def check(stream: InputStream) {
     check(scala.io.Source.fromInputStream(stream).mkString)


### PR DESCRIPTION
@throw -> @throws
@returns -> @return
