### PR TITLE
Need access to sequence on nodes created with modes EPHEMERAL_SEQUENTIAL or PERSISTENT_SEQUENTIAL

### DIFF
--- a/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
@@ -78,7 +78,7 @@ trait ZNode {
     zkClient.retrying { zk =>
       val result = new StringCallbackPromise
       zk.create(path, data, acls.asJava, mode, result, null)
-      result map { _ => this }
+      result map { newPath => ZNode(zkClient, newPath) }
     }
   }
 


### PR DESCRIPTION
The sequences on sequential nodes are required to implement many common zookeeper patterns, such as Leader-Election.

Here's the quick fix and the additional test.

Are you guys going to publish your parent scala pom? I'd love to at least be able to install jars locally (for scala 2.9.1), if not deploy snapshots to my company's local nexus, while waiting for you to pull this in.
