### PR TITLE
Fix Spool.foreachElem crashing on resoved spool with error

### DIFF
--- a/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
@@ -62,7 +62,7 @@ sealed trait Spool[+A] {
       // stacks in case a large portion
       // of the stream is already defined
       var next = tail
-      while (next.isDefined && !next().isEmpty) {
+      while (next.isDefined && next.isReturn && !next().isEmpty) {
         f(Some(next().head))
         next = next().tail
       }

--- a/util-core/src/test/scala/com/twitter/concurrent/SpoolSpec.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SpoolSpec.scala
@@ -37,6 +37,17 @@ class SpoolSpec extends SpecificationWithJUnit {
     }
   }
 
+  "Simple resolved spool with error" should {
+    val p = new Promise[Spool[Int]](Throw(new Exception("sad panda")))
+    val s = 1 **:: 2 *:: p
+
+    "EOF iteration on error" in {
+        val xs = new ArrayBuffer[Option[Int]]
+        s foreachElem { xs += _ }
+        xs.toSeq must be_==(Seq(Some(1), Some(2), None))
+    }
+  }
+
   "Simple delayed Spool" should {
     val p = new Promise[Spool[Int]]
     val p1 = new Promise[Spool[Int]]


### PR DESCRIPTION
`Spool.foreachElem(...)` crashes when called on resolved spool with an error. This is caused by `next()` evaluation without checking for `next.isReturn == true`.
