### PR TITLE
Make Spool.Empty public object

### DIFF
--- a/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
@@ -31,7 +31,7 @@ import com.twitter.util.{Future, Promise, Return}
  *   firstElem *:: rest
  * }}}
  */
-trait Spool[+A] {
+sealed trait Spool[+A] {
   import Spool.{cons, empty}
 
   def isEmpty: Boolean


### PR DESCRIPTION
In the following, for example, we should implement `case _ =>` pattern to prevent to get `MatchError` when `update` is invoked with `Future.value(Spool.empty[Int]))`:

```
import com.twitter.concurrent.Spool
import com.twitter.concurrent.Spool._
import com.twitter.util.Future

def update(changes: Future[Spool[Int]]) {
  changes foreach {
    case i *:: tail => println(i); update(tail)
    case _ => // Empty
  }
}
```

If `Spool.Empty` is public, we can clearly state our intention like the below:

```
def update(changes: Future[Spool[Int]]) {
  changes foreach {
    case i *:: tail => println(i); update(tail)
    case Empty =>
  }
}
```
