### PR TITLE
update import for util-collection

### DIFF
--- a/util-collection/src/main/scala/com/twitter/util/LruMap.scala
+++ b/util-collection/src/main/scala/com/twitter/util/LruMap.scala
@@ -1,7 +1,7 @@
 package com.twitter.util
 
 import org.apache.commons.collections.map.LRUMap
-import scala.collection.JavaConversions.JMapWrapper
+import scala.collection.convert.Wrappers.JMapWrapper
 import scala.collection.mutable.SynchronizedMap
 import java.util
 

--- a/util-collection/src/main/scala/com/twitter/util/SetMaker.scala
+++ b/util-collection/src/main/scala/com/twitter/util/SetMaker.scala
@@ -2,7 +2,7 @@ package com.twitter.util
 
 import scala.collection.mutable.{Map, Set}
 import java.util.concurrent.TimeUnit
-import collection.JavaConversions.JConcurrentMapWrapper
+import collection.convert.Wrappers.JConcurrentMapWrapper
 import com.google.common.collect.{MapMaker => GoogleMapMaker}
 
 object SetMaker {


### PR DESCRIPTION
update import for not using the Deprecated JavaConversions since 2.10.0, but the new import is not compatible for 2.9.x because the Wrappers object exists since 2.10.0
