### PR TITLE
util-zk: ZNode("/path").parentPath should be "/", not an empty string

### DIFF
--- a/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
@@ -56,7 +56,7 @@ trait ZNode {
   /** The parent node.  The root node is its own parent. */
   lazy val parent: ZNode = ZNode(zkClient, parentPath)
   lazy val parentPath: String = path.lastIndexOf('/') match {
-    case i if (i == -1 || i == path.length - 1) => path
+    case i if (i <= 0) => "/"
     case i => path.substring(0, i)
   }
 

--- a/util-zk/src/test/scala/com/twitter/zk/ZNodeSpec.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZNodeSpec.scala
@@ -20,6 +20,7 @@ class ZNodeSpec extends SpecificationWithJUnit with Mockito {
 
     pathTest("/", "/", "")
     pathTest("/some/long/path/to/a/znode", "/some/long/path/to/a", "znode")
+    pathTest("/path", "/", "path")
 
     "hash together" in {
       val zs = (0 to 1) map { _ => ZNode(zk, "/some/path") }


### PR DESCRIPTION
Also, zk path must start with "/" and not end with "/".
