### PR TITLE
restore prior Future.get behavior

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -534,8 +534,10 @@ abstract class Future[+A] extends Awaitable[A] {
    */
   @deprecated("Use Await.result", "6.2.x")
   final def get(timeout: Duration): Try[A] = {
-    Await.ready(this, timeout)
-    try Return(Await.result(this, Duration.Zero)) catch {
+    try {
+      Await.ready(this, timeout)
+      Return(Await.result(this, Duration.Zero))
+    } catch {
       // For legacy reasons, we catch even
       // fatal exceptions.
       case e => Throw(e)

--- a/util-core/src/test/scala/com/twitter/util/FutureSpec.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureSpec.scala
@@ -450,6 +450,12 @@ class FutureSpec extends SpecificationWithJUnit with Mockito {
         // Including fatal ones:
         val e2 = new java.lang.IllegalAccessError
         Future.exception[Int](e2).get(0.seconds)  must be_==(Throw(e2))
+
+        implicit val timer = new JavaTimer
+        val p = new Promise[Int]
+        val r = p.get(50.milliseconds)
+        r() must throwA[TimeoutException]
+        timer.stop()
       }
     }
 


### PR DESCRIPTION
In Finagle 5, Future.get would return a Throw(TimeoutException) for
timeouts:

  def get(timeout: Duration): Try[A] =
    ivar(timeout) getOrElse {
      Throw(new TimeoutException(timeout.toString))
    }

In Finagle 6, this behavior changed so that TimeoutException is
thrown instead. This is caused by Await.ready not being within the
try block.

Deprecated functions should not change beavior. This commit restores
that behavior.
