### PR TITLE
Add withFilter to Future and Try

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -634,6 +634,8 @@ abstract class Future[+A] extends Awaitable[A] {
 
   def filter(p: A => Boolean): Future[A] = transform { x: Try[A] => Future.const(x.filter(p)) }
 
+  def withFilter(p: A => Boolean): Future[A] = filter(p)
+
   /**
    * Invoke the function on the result, if the computation was
    * successful.  Returns a chained Future as in `respond`.

--- a/util-core/src/main/scala/com/twitter/util/Try.scala
+++ b/util-core/src/main/scala/com/twitter/util/Try.scala
@@ -72,6 +72,11 @@ sealed abstract class Try[+R] {
   def filter(p: R => Boolean): Try[R]
 
   /**
+   * Converts this to a Throw if the predicate does not obtain.
+   */
+  def withFilter(p: R => Boolean): Try[R]
+
+  /**
    * Calls the exceptionHandler with the exception if this is a Throw. This is like flatMap for the exception.
    *
    * ''Note'' The gnarly type parameterization is there for Java compatibility, since Java
@@ -150,6 +155,7 @@ final case class Throw[+R](e: Throwable) extends Try[R] {
   def flatten[T](implicit ev: R <:< Try[T]): Try[T] = Throw[T](e)
   def map[X](f: R => X) = Throw(e)
   def filter(p: R => Boolean) = this
+  def withFilter(p: R => Boolean) = this
   def onFailure(rescueException: Throwable => Unit) = { rescueException(e); this }
   def onSuccess(f: R => Unit) = this
   def handle[R2 >: R](rescueException: PartialFunction[Throwable, R2]) =
@@ -169,6 +175,7 @@ final case class Return[+R](r: R) extends Try[R] {
   def flatten[T](implicit ev: R <:< Try[T]): Try[T] = r
   def map[X](f: R => X) = Try[X](f(r))
   def filter(p: R => Boolean) = if (p(apply())) this else Throw(new Try.PredicateDoesNotObtain)
+  def withFilter(p: R => Boolean) = filter(p)
   def onFailure(rescueException: Throwable => Unit) = this
   def onSuccess(f: R => Unit) = { f(r); this }
   def handle[R2 >: R](rescueException: PartialFunction[Throwable, R2]) = this


### PR DESCRIPTION
Since Scala 2.8.x, guards in for-comprehensions will translate to a call to `withFilter` rather than `filter`. If no `withFilter` method is found, `filter` will be used instead but a deprecation warning will be emitted.

The contract for `withFilter`'s semantics are that the predicate be applied lazily. In Scala's standard library's collections, this is accomplished by `withFilter` returning an instance of intermediate class WithFilter, which is not itself a collection but has `map`/`flatMap`/`foreach` methods that apply both the filter predicate and the transformation in the same pass. See: https://github.com/scala/scala/blob/v2.10.1/src/library/scala/collection/TraversableLike.scala#L680

For collections with at most one element (such as Option, Try, or Future), the laziness or non-laziness of `withFilter` shouldn't matter. For example, Option's `withFilter` method does return an instance of a WithFilter class, but that class makes no attempt to make it's `map`/`flatMap`/`foreach` methods apply the predicate lazily: https://github.com/scala/scala/blob/v2.10.1/src/library/scala/Option.scala#L201

The included implementation forwards `withFilter` calls to `filter`. This removes the deprecation warning without changing the semantics of existing code. This is safe because laziness semantics are probably irrelevant to collections of at most one element. Further, the additional allocation of a new WithFilter instance could impact performance.
