### PR TITLE
Fix issues in bucket generation queue

### DIFF
--- a/util-collection/src/main/scala/com/twitter/collection/GenerationalQueue.scala
+++ b/util-collection/src/main/scala/com/twitter/collection/GenerationalQueue.scala
@@ -85,19 +85,17 @@ class BucketGenerationalQueue[A](timeout: Duration) extends GenerationalQueue[A]
   }
 
   private[this] val timeSlice = timeout / 3
-  private[this] var buckets = List(TimeBucket.empty[A])
+  private[this] var buckets = List[TimeBucket[A]]()
 
   private[this] def maybeGrowChain() = {
     // NB: age of youngest element is negative when bucket isn't expired
-    val bucket = buckets.head
-    if (bucket.age() > Duration.Zero) {
-      if (bucket.isEmpty)
-        buckets = List(TimeBucket.empty[A])
-      else
-        buckets = TimeBucket.empty[A] :: buckets
-      true
-    } else
-      false
+    val growChain = buckets.headOption.map((bucket) => {
+      bucket.age() > Duration.Zero
+    }).getOrElse(true)
+
+    if (growChain)
+      buckets = TimeBucket.empty[A] :: buckets
+    growChain
   }
 
   private[this] def compactChain(): List[TimeBucket[A]] = {


### PR DESCRIPTION
Bucket generation queue fails the simple test of

val queue = new BGQ[String](6 seconds)
-- wait for 3 seconds
queue.add(1)
queue.add(2)
queue.add(3)
--- wait for 4 seconds
queue.collect(2 seconds) -> return none

This and other errors occur due to a leading empty list for the oldest bucket.
This change maintains the invariant that there will not be a oldest empty bucket.
