### PR TITLE
Check whether JVM support thread measure before measuring.

### DIFF
--- a/util-core/src/main/scala/com/twitter/concurrent/Scheduler.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Scheduler.scala
@@ -88,7 +88,8 @@ private class LocalScheduler extends Scheduler {
       else if (r2 == null) r2 = r
       else rs.addLast(r)
       if (!running) {
-        if (rng.nextInt(SampleScale) == 0) {
+        if (rng.nextInt(SampleScale) == 0 &&
+          bean.isCurrentThreadCpuTimeSupported()) {
           numDispatches += SampleScale
           val cpu0 = bean.getCurrentThreadCpuTime()
           val usr0 = bean.getCurrentThreadUserTime()


### PR DESCRIPTION
Add ThreadMXBean.isCurrentThreadCpuTimeSupported before calling ThreadMXBean.getCurrentThreadCpuTime().

This should fix #76.
