### PR TITLE
Fix typo in Eval.scala

### DIFF
--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -74,7 +74,7 @@ class Eval(target: Option[File]) {
     classPathOfClass("scala.tools.nsc.Interpreter")
   } catch {
     case e: Throwable =>
-      throw new RuntimeException("Unable lo load scala interpreter from classpath (scala-compiler jar is missing?)", e)
+      throw new RuntimeException("Unable to load scala interpreter from classpath (scala-compiler jar is missing?)", e)
   }
 
   private lazy val libPath = try {


### PR DESCRIPTION
Small typo in one of the exception strings.
