### PR TITLE
Upgrade guava to 16.0.1

### DIFF
--- a/util-collection/pom.xml
+++ b/util-collection/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>15.0</version>
+      <version>16.0.1</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>


### PR DESCRIPTION
This patch upgrades guava dependency from 13.0.1 to 16.0.1, which is compatible with latest JDK 1.7 update 51 (see guava issue 1635 for more details).
