### PR TITLE
util-core: Fixes detachable semantics with ConstFuture

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -239,15 +239,15 @@ object Promise {
     case p: Promise[_] =>
       new DetachablePromise[A](p)
     case _ => {
-      new Promise[A] with Detachable {
+      val p = new Promise[A] with Detachable {
         private[this] val detached = new AtomicBoolean(false)
 
         def detach(): Boolean = detached.compareAndSet(false, true)
-
-        parent.respond { case t =>
-          if (detach()) update(t)
-        }
       }
+      parent respond { case t =>
+        if (p.detach()) p.update(t)
+      }
+      p
     }
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -46,8 +46,8 @@ class PromiseTest extends FunSuite with Eventually {
   test("Promise.attached should detach properly for futures") {
     val f = Future.Unit
     val p = Promise.attached(f)
-    assert(p.detach())
     assert(!p.detach())
+    assert(p.poll === Some(Return(())))
   }
 
   test("Detached promises are no longer connected: Success") {


### PR DESCRIPTION
## Motivation

Promise.attached on ConstFutures didn't work as you'd expect, which would be that it would fulfil the Promise and then detach it.
## Modification

Changes the parent.respond to execute outside of the class initialization.
## Result

Promise.attached is significantly easier to reason about with ConstFutures.
