### PR TITLE
Allow undefined flags through `allowUndefinedFlags`.

### DIFF
--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -110,7 +110,7 @@ trait App extends Closable with CloseAwaitably {
   final def main(args: Array[String]) {
     for (f <- inits) f()
 
-    _args = flag.parseOrExit1(args).toArray
+    _args = flag.parseOrExit1(args, false).toArray
 
     for (f <- premains) f()
 


### PR DESCRIPTION
The default behaviour of App with respect to undefined flags (allowing them) is rather surprising given that most flag parsing libraries will barf if passed a flag they don't know about (useful for catching typos etc). This change leaves the default behaviour intact, but allows undefined flags to be disallowed through the `allowUndefinedFlags` def.
