### PR TITLE
Update README to reflect correct storage units.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,8 +33,8 @@ duration1.inMillis // => 1000L
 ```scala
 import com.twitter.conversions.storage._
 val amount = 8.megabytes
-amount.inBytes // => 8192L
-amount.inGigabytes // => 0.0078125
+amount.inBytes // => 8388608L
+amount.inKilobytes // => 8192L
 ```
 
 # Futures


### PR DESCRIPTION
Problem:

The prior example text in the README is incorrect:
- There are ~8 million bytes to the megabyte, not 8,192.
- The conversions library uses integer math; < 1 GB is reflected as '0'
  when the toGigabytes conversion is applied. The docs falsely imply
  that floating-point division is supported by the library.

Solution:
- Updated README.markdown to use examples that are not misleading, and
  that reflect the true output of scala interactive shell.
