### PR TITLE
Add redirects from old API docs to new

### DIFF
--- a/util-collection/target/doc/main/api/com/package.html
+++ b/util-collection/target/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/package.html
+++ b/util-collection/target/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/LruMap$.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/LruMap$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.LruMap$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap$" />
           <title>com.twitter.util.LruMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/LruMap.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/LruMap.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.LruMap" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap" />
           <title>com.twitter.util.LruMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/MapMaker$$Config.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/MapMaker$$Config.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$$Config" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$$Config/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$$Config" />
           <title>com.twitter.util.MapMaker.Config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/MapMaker$.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/MapMaker$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$" />
           <title>com.twitter.util.MapMaker</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/MapToSetAdapter.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/MapToSetAdapter.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.MapToSetAdapter" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapToSetAdapter/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapToSetAdapter" />
           <title>com.twitter.util.MapToSetAdapter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/SetMaker$$Config.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/SetMaker$$Config.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$$Config" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$$Config/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$$Config" />
           <title>com.twitter.util.SetMaker.Config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/SetMaker$.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/SetMaker$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$" />
           <title>com.twitter.util.SetMaker</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/SynchronizedLruMap.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/SynchronizedLruMap.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SynchronizedLruMap" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SynchronizedLruMap/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SynchronizedLruMap" />
           <title>com.twitter.util.SynchronizedLruMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/com/twitter/util/package.html
+++ b/util-collection/target/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/index.html
+++ b/util-collection/target/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.collection.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package" />
           <title>util-collection 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/doc/main/api/package.html
+++ b/util-collection/target/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.collection.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/package.html
+++ b/util-collection/target/site/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/package.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/LruMap$.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/LruMap$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.LruMap$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap$" />
           <title>com.twitter.util.LruMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/LruMap.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/LruMap.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.LruMap" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LruMap" />
           <title>com.twitter.util.LruMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/MapMaker$$Config.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/MapMaker$$Config.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$$Config" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$$Config/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$$Config" />
           <title>com.twitter.util.MapMaker.Config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/MapMaker$.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/MapMaker$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$" />
           <title>com.twitter.util.MapMaker</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/MapToSetAdapter.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/MapToSetAdapter.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.MapToSetAdapter" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapToSetAdapter/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.MapToSetAdapter" />
           <title>com.twitter.util.MapToSetAdapter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/SetMaker$$Config.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/SetMaker$$Config.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$$Config" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$$Config/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$$Config" />
           <title>com.twitter.util.SetMaker.Config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/SetMaker$.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/SetMaker$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SetMaker$" />
           <title>com.twitter.util.SetMaker</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/SynchronizedLruMap.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/SynchronizedLruMap.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SynchronizedLruMap" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SynchronizedLruMap/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SynchronizedLruMap" />
           <title>com.twitter.util.SynchronizedLruMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/com/twitter/util/package.html
+++ b/util-collection/target/site/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/index.html
+++ b/util-collection/target/site/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.collection.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package" />
           <title>util-collection 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/doc/main/api/package.html
+++ b/util-collection/target/site/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.collection.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-collection/target/site/index.html
+++ b/util-collection/target/site/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.collection.package" />
-  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package/" />
+  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.collection.package" />
 <title>util-collection</title>
 </head>
 <body>

--- a/util-core/target/doc/main/api/com/package.html
+++ b/util-core/target/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/AsyncMutex.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/AsyncMutex.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncMutex" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncMutex/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncMutex" />
           <title>com.twitter.concurrent.AsyncMutex</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/AsyncSemaphore.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/AsyncSemaphore.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncSemaphore" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncSemaphore/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncSemaphore" />
           <title>com.twitter.concurrent.AsyncSemaphore</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/Channel.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/Channel.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Channel" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Channel/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Channel" />
           <title>com.twitter.concurrent.Channel</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/ChannelSource.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/ChannelSource.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ChannelSource" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ChannelSource/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ChannelSource" />
           <title>com.twitter.concurrent.ChannelSource</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentBijection.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentBijection.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentBijection" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentBijection/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentBijection" />
           <title>com.twitter.concurrent.ConcurrentBijection</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap$Container.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap$Container.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap$Container" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap$Container/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap$Container" />
           <title>com.twitter.concurrent.ConcurrentMultiMap.Container</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap" />
           <title>com.twitter.concurrent.ConcurrentMultiMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentPool.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/ConcurrentPool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentPool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentPool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentPool" />
           <title>com.twitter.concurrent.ConcurrentPool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/NamedPoolThreadFactory.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/NamedPoolThreadFactory.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.NamedPoolThreadFactory" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.NamedPoolThreadFactory/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.NamedPoolThreadFactory" />
           <title>com.twitter.concurrent.NamedPoolThreadFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/Observer.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/Observer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Observer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Observer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Observer" />
           <title>com.twitter.concurrent.Observer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/ObserverSource.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/ObserverSource.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ObserverSource" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ObserverSource/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ObserverSource" />
           <title>com.twitter.concurrent.ObserverSource</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/Permit.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/Permit.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Permit" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Permit/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Permit" />
           <title>com.twitter.concurrent.Permit</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/Serialized$Job.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/Serialized$Job.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized$Job" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized$Job/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized$Job" />
           <title>com.twitter.concurrent.Serialized.Job</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/Serialized.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/Serialized.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized" />
           <title>com.twitter.concurrent.Serialized</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/concurrent/package.html
+++ b/util-core/target/doc/main/api/com/twitter/concurrent/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.package" />
           <title>com.twitter.concurrent</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/package.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.package" />
           <title>com.twitter.conversions</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/storage$$RichWholeNumber.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/storage$$RichWholeNumber.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.storage$$RichWholeNumber" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$$RichWholeNumber/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$$RichWholeNumber" />
           <title>com.twitter.conversions.storage.RichWholeNumber</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/storage$.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/storage$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.storage$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$" />
           <title>com.twitter.conversions.storage</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/string$$RichByteArray.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/string$$RichByteArray.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichByteArray" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichByteArray/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichByteArray" />
           <title>com.twitter.conversions.string.RichByteArray</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/string$$RichString.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/string$$RichString.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichString" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichString/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichString" />
           <title>com.twitter.conversions.string.RichString</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/string$.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/string$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.string$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$" />
           <title>com.twitter.conversions.string</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/thread$.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/thread$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.thread$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.thread$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.thread$" />
           <title>com.twitter.conversions.thread</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/time$$RichWholeNumber.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/time$$RichWholeNumber.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.time$$RichWholeNumber" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$$RichWholeNumber/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$$RichWholeNumber" />
           <title>com.twitter.conversions.time.RichWholeNumber</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/conversions/time$.html
+++ b/util-core/target/doc/main/api/com/twitter/conversions/time$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.time$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$" />
           <title>com.twitter.conversions.time</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/package.html
+++ b/util-core/target/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator$.html
+++ b/util-core/target/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator$" />
           <title>com.twitter.service.VirtualMachineErrorTerminator</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator.html
+++ b/util-core/target/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator" />
           <title>com.twitter.service.VirtualMachineErrorTerminator</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/service/package.html
+++ b/util-core/target/doc/main/api/com/twitter/service/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.service.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.package" />
           <title>com.twitter.service</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Base64StringEncoder.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Base64StringEncoder.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Base64StringEncoder" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Base64StringEncoder/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Base64StringEncoder" />
           <title>com.twitter.util.Base64StringEncoder</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/BoundedStack.html
+++ b/util-core/target/doc/main/api/com/twitter/util/BoundedStack.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.BoundedStack" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BoundedStack/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BoundedStack" />
           <title>com.twitter.util.BoundedStack</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Command.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Command.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Command" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Command/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Command" />
           <title>com.twitter.util.Command</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Config.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Config.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Config" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Config/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Config" />
           <title>com.twitter.util.Config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/CountDownLatch.html
+++ b/util-core/target/doc/main/api/com/twitter/util/CountDownLatch.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.CountDownLatch" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CountDownLatch/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CountDownLatch" />
           <title>com.twitter.util.CountDownLatch</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Duration$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Duration$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Duration$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration$" />
           <title>com.twitter.util.Duration</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Duration.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Duration.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Duration" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration" />
           <title>com.twitter.util.Duration</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/FactoryPool.html
+++ b/util-core/target/doc/main/api/com/twitter/util/FactoryPool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FactoryPool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FactoryPool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FactoryPool" />
           <title>com.twitter.util.FactoryPool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Function.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Function.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Function" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function" />
           <title>com.twitter.util.Function</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Function2.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Function2.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Function2" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function2/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function2" />
           <title>com.twitter.util.Function2</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Future$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Future$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Future$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future$" />
           <title>com.twitter.util.Future</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Future.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Future.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Future" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future" />
           <title>com.twitter.util.Future</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/FutureEventListener.html
+++ b/util-core/target/doc/main/api/com/twitter/util/FutureEventListener.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FutureEventListener" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureEventListener/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureEventListener" />
           <title>com.twitter.util.FutureEventListener</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/FuturePool.html
+++ b/util-core/target/doc/main/api/com/twitter/util/FuturePool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FuturePool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FuturePool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FuturePool" />
           <title>com.twitter.util.FuturePool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/FutureTask$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/FutureTask$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FutureTask$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask$" />
           <title>com.twitter.util.FutureTask</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/FutureTask.html
+++ b/util-core/target/doc/main/api/com/twitter/util/FutureTask.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FutureTask" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask" />
           <title>com.twitter.util.FutureTask</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/HandleSignal$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/HandleSignal$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.HandleSignal$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.HandleSignal$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.HandleSignal$" />
           <title>com.twitter.util.HandleSignal</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/JavaTimer.html
+++ b/util-core/target/doc/main/api/com/twitter/util/JavaTimer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.JavaTimer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JavaTimer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JavaTimer" />
           <title>com.twitter.util.JavaTimer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/LastWriteWinsQueue.html
+++ b/util-core/target/doc/main/api/com/twitter/util/LastWriteWinsQueue.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.LastWriteWinsQueue" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LastWriteWinsQueue/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LastWriteWinsQueue" />
           <title>com.twitter.util.LastWriteWinsQueue</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Local.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Local.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Local" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Local/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Local" />
           <title>com.twitter.util.Local</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Locals$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Locals$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Locals$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Locals$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Locals$" />
           <title>com.twitter.util.Locals</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Pool.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Pool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Pool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Pool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Pool" />
           <title>com.twitter.util.Pool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Promise$$ImmutableResult.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Promise$$ImmutableResult.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Promise$$ImmutableResult" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$$ImmutableResult/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$$ImmutableResult" />
           <title>com.twitter.util.Promise.ImmutableResult</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Promise$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Promise$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Promise$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$" />
           <title>com.twitter.util.Promise</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Promise.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Promise.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Promise" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise" />
           <title>com.twitter.util.Promise</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/RandomSocket$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/RandomSocket$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RandomSocket$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RandomSocket$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RandomSocket$" />
           <title>com.twitter.util.RandomSocket</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/ReferenceCountedTimer.html
+++ b/util-core/target/doc/main/api/com/twitter/util/ReferenceCountedTimer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.ReferenceCountedTimer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ReferenceCountedTimer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ReferenceCountedTimer" />
           <title>com.twitter.util.ReferenceCountedTimer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Return.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Return.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Return" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Return/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Return" />
           <title>com.twitter.util.Return</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/RichU64ByteArray.html
+++ b/util-core/target/doc/main/api/com/twitter/util/RichU64ByteArray.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RichU64ByteArray" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64ByteArray/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64ByteArray" />
           <title>com.twitter.util.RichU64ByteArray</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/RichU64Long.html
+++ b/util-core/target/doc/main/api/com/twitter/util/RichU64Long.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RichU64Long" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64Long/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64Long" />
           <title>com.twitter.util.RichU64Long</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/RichU64String.html
+++ b/util-core/target/doc/main/api/com/twitter/util/RichU64String.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RichU64String" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64String/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64String" />
           <title>com.twitter.util.RichU64String</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/RingBuffer.html
+++ b/util-core/target/doc/main/api/com/twitter/util/RingBuffer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RingBuffer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RingBuffer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RingBuffer" />
           <title>com.twitter.util.RingBuffer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/SavedLocal.html
+++ b/util-core/target/doc/main/api/com/twitter/util/SavedLocal.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SavedLocal" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocal/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocal" />
           <title>com.twitter.util.SavedLocal</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/SavedLocals.html
+++ b/util-core/target/doc/main/api/com/twitter/util/SavedLocals.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SavedLocals" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocals/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocals" />
           <title>com.twitter.util.SavedLocals</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/ScheduledThreadPoolTimer.html
+++ b/util-core/target/doc/main/api/com/twitter/util/ScheduledThreadPoolTimer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.ScheduledThreadPoolTimer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ScheduledThreadPoolTimer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ScheduledThreadPoolTimer" />
           <title>com.twitter.util.ScheduledThreadPoolTimer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/SignalHandler.html
+++ b/util-core/target/doc/main/api/com/twitter/util/SignalHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SignalHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandler" />
           <title>com.twitter.util.SignalHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/SignalHandlerFactory$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/SignalHandlerFactory$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SignalHandlerFactory$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandlerFactory$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandlerFactory$" />
           <title>com.twitter.util.SignalHandlerFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/SimplePool.html
+++ b/util-core/target/doc/main/api/com/twitter/util/SimplePool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SimplePool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SimplePool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SimplePool" />
           <title>com.twitter.util.SimplePool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StateMachine$$InvalidStateTransition.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StateMachine$$InvalidStateTransition.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$$InvalidStateTransition" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$$InvalidStateTransition/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$$InvalidStateTransition" />
           <title>com.twitter.util.StateMachine.InvalidStateTransition</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StateMachine$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StateMachine$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$" />
           <title>com.twitter.util.StateMachine</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StateMachine$State.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StateMachine$State.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$State" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$State/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$State" />
           <title>com.twitter.util.StateMachine.State</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StateMachine.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StateMachine.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine" />
           <title>com.twitter.util.StateMachine</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StorageUnit$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StorageUnit$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit$" />
           <title>com.twitter.util.StorageUnit</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StorageUnit.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StorageUnit.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit" />
           <title>com.twitter.util.StorageUnit</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StreamHelper$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StreamHelper$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StreamHelper$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StreamHelper$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StreamHelper$" />
           <title>com.twitter.util.StreamHelper</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/StringEncoder.html
+++ b/util-core/target/doc/main/api/com/twitter/util/StringEncoder.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StringEncoder" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StringEncoder/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StringEncoder" />
           <title>com.twitter.util.StringEncoder</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/SunSignalHandler$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/SunSignalHandler$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler$" />
           <title>com.twitter.util.SunSignalHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/SunSignalHandler.html
+++ b/util-core/target/doc/main/api/com/twitter/util/SunSignalHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler" />
           <title>com.twitter.util.SunSignalHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TempFolder.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TempFolder.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TempFolder" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TempFolder/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TempFolder" />
           <title>com.twitter.util.TempFolder</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Throw.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Throw.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Throw" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Throw/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Throw" />
           <title>com.twitter.util.Throw</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Time$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Time$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Time$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time$" />
           <title>com.twitter.util.Time</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Time.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Time.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Time" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time" />
           <title>com.twitter.util.Time</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TimeControl.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TimeControl.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeControl" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeControl/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeControl" />
           <title>com.twitter.util.TimeControl</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TimeFormat.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TimeFormat.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeFormat" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeFormat/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeFormat" />
           <title>com.twitter.util.TimeFormat</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TimeLike.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TimeLike.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeLike" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeLike/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeLike" />
           <title>com.twitter.util.TimeLike</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TimeMath$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TimeMath$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeMath$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeMath$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeMath$" />
           <title>com.twitter.util.TimeMath</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TimeOverflowException.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TimeOverflowException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeOverflowException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeOverflowException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeOverflowException" />
           <title>com.twitter.util.TimeOverflowException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TimeoutException.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TimeoutException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeoutException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeoutException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeoutException" />
           <title>com.twitter.util.TimeoutException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Timer.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Timer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Timer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Timer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Timer" />
           <title>com.twitter.util.Timer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TimerTask.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TimerTask.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimerTask" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimerTask/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimerTask" />
           <title>com.twitter.util.TimerTask</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Try$$PredicateDoesNotObtain.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Try$$PredicateDoesNotObtain.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Try$$PredicateDoesNotObtain" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$$PredicateDoesNotObtain/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$$PredicateDoesNotObtain" />
           <title>com.twitter.util.Try.PredicateDoesNotObtain</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Try$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Try$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Try$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$" />
           <title>com.twitter.util.Try</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/Try.html
+++ b/util-core/target/doc/main/api/com/twitter/util/Try.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Try" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try" />
           <title>com.twitter.util.Try</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/TryLike.html
+++ b/util-core/target/doc/main/api/com/twitter/util/TryLike.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TryLike" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TryLike/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TryLike" />
           <title>com.twitter.util.TryLike</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/U64$.html
+++ b/util-core/target/doc/main/api/com/twitter/util/U64$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.U64$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.U64$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.U64$" />
           <title>com.twitter.util.U64</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/package.html
+++ b/util-core/target/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/repository/CachingRepository.html
+++ b/util-core/target/doc/main/api/com/twitter/util/repository/CachingRepository.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.repository.CachingRepository" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.CachingRepository/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.CachingRepository" />
           <title>com.twitter.util.repository.CachingRepository</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/repository/Repository.html
+++ b/util-core/target/doc/main/api/com/twitter/util/repository/Repository.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.repository.Repository" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.Repository/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.Repository" />
           <title>com.twitter.util.repository.Repository</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/com/twitter/util/repository/package.html
+++ b/util-core/target/doc/main/api/com/twitter/util/repository/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.repository.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.package" />
           <title>com.twitter.util.repository</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/index.html
+++ b/util-core/target/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>util-core 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/doc/main/api/package.html
+++ b/util-core/target/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/package.html
+++ b/util-core/target/site/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/AsyncMutex.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/AsyncMutex.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncMutex" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncMutex/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncMutex" />
           <title>com.twitter.concurrent.AsyncMutex</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/AsyncSemaphore.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/AsyncSemaphore.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncSemaphore" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncSemaphore/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.AsyncSemaphore" />
           <title>com.twitter.concurrent.AsyncSemaphore</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/Channel.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/Channel.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Channel" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Channel/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Channel" />
           <title>com.twitter.concurrent.Channel</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/ChannelSource.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/ChannelSource.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ChannelSource" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ChannelSource/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ChannelSource" />
           <title>com.twitter.concurrent.ChannelSource</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentBijection.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentBijection.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentBijection" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentBijection/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentBijection" />
           <title>com.twitter.concurrent.ConcurrentBijection</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap$Container.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap$Container.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap$Container" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap$Container/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap$Container" />
           <title>com.twitter.concurrent.ConcurrentMultiMap.Container</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentMultiMap.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentMultiMap" />
           <title>com.twitter.concurrent.ConcurrentMultiMap</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentPool.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/ConcurrentPool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentPool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentPool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ConcurrentPool" />
           <title>com.twitter.concurrent.ConcurrentPool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/NamedPoolThreadFactory.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/NamedPoolThreadFactory.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.NamedPoolThreadFactory" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.NamedPoolThreadFactory/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.NamedPoolThreadFactory" />
           <title>com.twitter.concurrent.NamedPoolThreadFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/Observer.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/Observer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Observer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Observer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Observer" />
           <title>com.twitter.concurrent.Observer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/ObserverSource.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/ObserverSource.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.ObserverSource" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ObserverSource/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.ObserverSource" />
           <title>com.twitter.concurrent.ObserverSource</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/Permit.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/Permit.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Permit" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Permit/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Permit" />
           <title>com.twitter.concurrent.Permit</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/Serialized$Job.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/Serialized$Job.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized$Job" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized$Job/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized$Job" />
           <title>com.twitter.concurrent.Serialized.Job</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/Serialized.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/Serialized.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.Serialized" />
           <title>com.twitter.concurrent.Serialized</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/concurrent/package.html
+++ b/util-core/target/site/doc/main/api/com/twitter/concurrent/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.concurrent.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.concurrent.package" />
           <title>com.twitter.concurrent</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/package.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.package" />
           <title>com.twitter.conversions</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/storage$$RichWholeNumber.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/storage$$RichWholeNumber.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.storage$$RichWholeNumber" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$$RichWholeNumber/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$$RichWholeNumber" />
           <title>com.twitter.conversions.storage.RichWholeNumber</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/storage$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/storage$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.storage$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.storage$" />
           <title>com.twitter.conversions.storage</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/string$$RichByteArray.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/string$$RichByteArray.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichByteArray" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichByteArray/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichByteArray" />
           <title>com.twitter.conversions.string.RichByteArray</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/string$$RichString.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/string$$RichString.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichString" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichString/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$$RichString" />
           <title>com.twitter.conversions.string.RichString</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/string$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/string$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.string$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.string$" />
           <title>com.twitter.conversions.string</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/thread$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/thread$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.thread$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.thread$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.thread$" />
           <title>com.twitter.conversions.thread</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/time$$RichWholeNumber.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/time$$RichWholeNumber.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.time$$RichWholeNumber" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$$RichWholeNumber/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$$RichWholeNumber" />
           <title>com.twitter.conversions.time.RichWholeNumber</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/conversions/time$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/conversions/time$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.conversions.time$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.conversions.time$" />
           <title>com.twitter.conversions.time</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/package.html
+++ b/util-core/target/site/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator$" />
           <title>com.twitter.service.VirtualMachineErrorTerminator</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator.html
+++ b/util-core/target/site/doc/main/api/com/twitter/service/VirtualMachineErrorTerminator.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.VirtualMachineErrorTerminator" />
           <title>com.twitter.service.VirtualMachineErrorTerminator</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/service/package.html
+++ b/util-core/target/site/doc/main/api/com/twitter/service/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.service.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.service.package" />
           <title>com.twitter.service</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Base64StringEncoder.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Base64StringEncoder.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Base64StringEncoder" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Base64StringEncoder/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Base64StringEncoder" />
           <title>com.twitter.util.Base64StringEncoder</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/BoundedStack.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/BoundedStack.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.BoundedStack" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BoundedStack/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BoundedStack" />
           <title>com.twitter.util.BoundedStack</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Command.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Command.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Command" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Command/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Command" />
           <title>com.twitter.util.Command</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Config.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Config.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Config" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Config/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Config" />
           <title>com.twitter.util.Config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/CountDownLatch.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/CountDownLatch.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.CountDownLatch" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CountDownLatch/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CountDownLatch" />
           <title>com.twitter.util.CountDownLatch</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Duration$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Duration$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Duration$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration$" />
           <title>com.twitter.util.Duration</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Duration.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Duration.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Duration" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Duration" />
           <title>com.twitter.util.Duration</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/FactoryPool.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/FactoryPool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FactoryPool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FactoryPool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FactoryPool" />
           <title>com.twitter.util.FactoryPool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Function.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Function.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Function" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function" />
           <title>com.twitter.util.Function</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Function2.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Function2.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Function2" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function2/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Function2" />
           <title>com.twitter.util.Function2</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Future$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Future$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Future$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future$" />
           <title>com.twitter.util.Future</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Future.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Future.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Future" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Future" />
           <title>com.twitter.util.Future</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/FutureEventListener.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/FutureEventListener.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FutureEventListener" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureEventListener/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureEventListener" />
           <title>com.twitter.util.FutureEventListener</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/FuturePool.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/FuturePool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FuturePool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FuturePool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FuturePool" />
           <title>com.twitter.util.FuturePool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/FutureTask$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/FutureTask$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FutureTask$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask$" />
           <title>com.twitter.util.FutureTask</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/FutureTask.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/FutureTask.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.FutureTask" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.FutureTask" />
           <title>com.twitter.util.FutureTask</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/HandleSignal$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/HandleSignal$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.HandleSignal$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.HandleSignal$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.HandleSignal$" />
           <title>com.twitter.util.HandleSignal</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/JavaTimer.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/JavaTimer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.JavaTimer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JavaTimer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JavaTimer" />
           <title>com.twitter.util.JavaTimer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/LastWriteWinsQueue.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/LastWriteWinsQueue.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.LastWriteWinsQueue" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LastWriteWinsQueue/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.LastWriteWinsQueue" />
           <title>com.twitter.util.LastWriteWinsQueue</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Local.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Local.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Local" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Local/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Local" />
           <title>com.twitter.util.Local</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Locals$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Locals$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Locals$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Locals$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Locals$" />
           <title>com.twitter.util.Locals</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Pool.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Pool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Pool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Pool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Pool" />
           <title>com.twitter.util.Pool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Promise$$ImmutableResult.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Promise$$ImmutableResult.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Promise$$ImmutableResult" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$$ImmutableResult/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$$ImmutableResult" />
           <title>com.twitter.util.Promise.ImmutableResult</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Promise$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Promise$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Promise$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise$" />
           <title>com.twitter.util.Promise</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Promise.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Promise.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Promise" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Promise" />
           <title>com.twitter.util.Promise</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/RandomSocket$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/RandomSocket$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RandomSocket$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RandomSocket$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RandomSocket$" />
           <title>com.twitter.util.RandomSocket</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/ReferenceCountedTimer.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/ReferenceCountedTimer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.ReferenceCountedTimer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ReferenceCountedTimer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ReferenceCountedTimer" />
           <title>com.twitter.util.ReferenceCountedTimer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Return.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Return.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Return" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Return/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Return" />
           <title>com.twitter.util.Return</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/RichU64ByteArray.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/RichU64ByteArray.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RichU64ByteArray" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64ByteArray/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64ByteArray" />
           <title>com.twitter.util.RichU64ByteArray</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/RichU64Long.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/RichU64Long.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RichU64Long" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64Long/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64Long" />
           <title>com.twitter.util.RichU64Long</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/RichU64String.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/RichU64String.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RichU64String" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64String/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RichU64String" />
           <title>com.twitter.util.RichU64String</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/RingBuffer.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/RingBuffer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.RingBuffer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RingBuffer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.RingBuffer" />
           <title>com.twitter.util.RingBuffer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/SavedLocal.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/SavedLocal.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SavedLocal" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocal/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocal" />
           <title>com.twitter.util.SavedLocal</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/SavedLocals.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/SavedLocals.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SavedLocals" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocals/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SavedLocals" />
           <title>com.twitter.util.SavedLocals</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/ScheduledThreadPoolTimer.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/ScheduledThreadPoolTimer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.ScheduledThreadPoolTimer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ScheduledThreadPoolTimer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ScheduledThreadPoolTimer" />
           <title>com.twitter.util.ScheduledThreadPoolTimer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/SignalHandler.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/SignalHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SignalHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandler" />
           <title>com.twitter.util.SignalHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/SignalHandlerFactory$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/SignalHandlerFactory$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SignalHandlerFactory$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandlerFactory$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SignalHandlerFactory$" />
           <title>com.twitter.util.SignalHandlerFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/SimplePool.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/SimplePool.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SimplePool" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SimplePool/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SimplePool" />
           <title>com.twitter.util.SimplePool</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StateMachine$$InvalidStateTransition.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StateMachine$$InvalidStateTransition.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$$InvalidStateTransition" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$$InvalidStateTransition/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$$InvalidStateTransition" />
           <title>com.twitter.util.StateMachine.InvalidStateTransition</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StateMachine$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StateMachine$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$" />
           <title>com.twitter.util.StateMachine</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StateMachine$State.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StateMachine$State.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$State" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$State/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine$State" />
           <title>com.twitter.util.StateMachine.State</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StateMachine.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StateMachine.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StateMachine" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StateMachine" />
           <title>com.twitter.util.StateMachine</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StorageUnit$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StorageUnit$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit$" />
           <title>com.twitter.util.StorageUnit</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StorageUnit.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StorageUnit.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StorageUnit" />
           <title>com.twitter.util.StorageUnit</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StreamHelper$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StreamHelper$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StreamHelper$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StreamHelper$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StreamHelper$" />
           <title>com.twitter.util.StreamHelper</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/StringEncoder.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/StringEncoder.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.StringEncoder" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StringEncoder/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.StringEncoder" />
           <title>com.twitter.util.StringEncoder</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/SunSignalHandler$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/SunSignalHandler$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler$" />
           <title>com.twitter.util.SunSignalHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/SunSignalHandler.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/SunSignalHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.SunSignalHandler" />
           <title>com.twitter.util.SunSignalHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TempFolder.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TempFolder.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TempFolder" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TempFolder/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TempFolder" />
           <title>com.twitter.util.TempFolder</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Throw.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Throw.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Throw" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Throw/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Throw" />
           <title>com.twitter.util.Throw</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Time$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Time$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Time$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time$" />
           <title>com.twitter.util.Time</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Time.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Time.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Time" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Time" />
           <title>com.twitter.util.Time</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TimeControl.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TimeControl.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeControl" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeControl/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeControl" />
           <title>com.twitter.util.TimeControl</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TimeFormat.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TimeFormat.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeFormat" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeFormat/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeFormat" />
           <title>com.twitter.util.TimeFormat</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TimeLike.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TimeLike.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeLike" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeLike/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeLike" />
           <title>com.twitter.util.TimeLike</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TimeMath$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TimeMath$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeMath$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeMath$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeMath$" />
           <title>com.twitter.util.TimeMath</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TimeOverflowException.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TimeOverflowException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeOverflowException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeOverflowException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeOverflowException" />
           <title>com.twitter.util.TimeOverflowException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TimeoutException.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TimeoutException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimeoutException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeoutException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimeoutException" />
           <title>com.twitter.util.TimeoutException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Timer.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Timer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Timer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Timer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Timer" />
           <title>com.twitter.util.Timer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TimerTask.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TimerTask.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TimerTask" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimerTask/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TimerTask" />
           <title>com.twitter.util.TimerTask</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Try$$PredicateDoesNotObtain.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Try$$PredicateDoesNotObtain.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Try$$PredicateDoesNotObtain" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$$PredicateDoesNotObtain/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$$PredicateDoesNotObtain" />
           <title>com.twitter.util.Try.PredicateDoesNotObtain</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Try$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Try$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Try$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try$" />
           <title>com.twitter.util.Try</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/Try.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/Try.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Try" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Try" />
           <title>com.twitter.util.Try</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/TryLike.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/TryLike.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.TryLike" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TryLike/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.TryLike" />
           <title>com.twitter.util.TryLike</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/U64$.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/U64$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.U64$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.U64$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.U64$" />
           <title>com.twitter.util.U64</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/package.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/repository/CachingRepository.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/repository/CachingRepository.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.repository.CachingRepository" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.CachingRepository/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.CachingRepository" />
           <title>com.twitter.util.repository.CachingRepository</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/repository/Repository.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/repository/Repository.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.repository.Repository" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.Repository/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.Repository" />
           <title>com.twitter.util.repository.Repository</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/com/twitter/util/repository/package.html
+++ b/util-core/target/site/doc/main/api/com/twitter/util/repository/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.repository.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.repository.package" />
           <title>com.twitter.util.repository</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/index.html
+++ b/util-core/target/site/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>util-core 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/doc/main/api/package.html
+++ b/util-core/target/site/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-core/target/site/index.html
+++ b/util-core/target/site/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
 <title>util-core</title>
 </head>
 <body>

--- a/util-eval/target/doc/main/api/com/package.html
+++ b/util-eval/target/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/doc/main/api/com/twitter/package.html
+++ b/util-eval/target/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/doc/main/api/com/twitter/util/Eval$$CompilerException.html
+++ b/util-eval/target/doc/main/api/com/twitter/util/Eval$$CompilerException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Eval$$CompilerException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$CompilerException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$CompilerException" />
           <title>com.twitter.util.Eval.CompilerException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/doc/main/api/com/twitter/util/Eval$$StringCompiler.html
+++ b/util-eval/target/doc/main/api/com/twitter/util/Eval$$StringCompiler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Eval$$StringCompiler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$StringCompiler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$StringCompiler" />
           <title>com.twitter.util.Eval.StringCompiler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/doc/main/api/com/twitter/util/Eval$.html
+++ b/util-eval/target/doc/main/api/com/twitter/util/Eval$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Eval$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$" />
           <title>com.twitter.util.Eval</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/doc/main/api/com/twitter/util/package.html
+++ b/util-eval/target/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/doc/main/api/index.html
+++ b/util-eval/target/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>util-eval 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/doc/main/api/package.html
+++ b/util-eval/target/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/com/package.html
+++ b/util-eval/target/site/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/com/twitter/package.html
+++ b/util-eval/target/site/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/com/twitter/util/Eval$$CompilerException.html
+++ b/util-eval/target/site/doc/main/api/com/twitter/util/Eval$$CompilerException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Eval$$CompilerException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$CompilerException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$CompilerException" />
           <title>com.twitter.util.Eval.CompilerException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/com/twitter/util/Eval$$StringCompiler.html
+++ b/util-eval/target/site/doc/main/api/com/twitter/util/Eval$$StringCompiler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Eval$$StringCompiler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$StringCompiler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$$StringCompiler" />
           <title>com.twitter.util.Eval.StringCompiler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/com/twitter/util/Eval$.html
+++ b/util-eval/target/site/doc/main/api/com/twitter/util/Eval$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.Eval$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.Eval$" />
           <title>com.twitter.util.Eval</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/com/twitter/util/package.html
+++ b/util-eval/target/site/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/index.html
+++ b/util-eval/target/site/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>util-eval 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/doc/main/api/package.html
+++ b/util-eval/target/site/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-eval/target/site/index.html
+++ b/util-eval/target/site/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
 <title>util-eval</title>
 </head>
 <body>

--- a/util-logging/target/doc/main/api/com/package.html
+++ b/util-logging/target/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/BareFormatter$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/BareFormatter$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.BareFormatter$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BareFormatter$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BareFormatter$" />
           <title>com.twitter.logging.BareFormatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/BasicFormatter$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/BasicFormatter$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.BasicFormatter$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BasicFormatter$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BasicFormatter$" />
           <title>com.twitter.logging.BasicFormatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/ConsoleHandler.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/ConsoleHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ConsoleHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ConsoleHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ConsoleHandler" />
           <title>com.twitter.logging.ConsoleHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/FileHandler.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/FileHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.FileHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.FileHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.FileHandler" />
           <title>com.twitter.logging.FileHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Formatter.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Formatter.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Formatter" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Formatter/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Formatter" />
           <title>com.twitter.logging.Formatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Handler.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Handler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Handler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Handler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Handler" />
           <title>com.twitter.logging.Handler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/LazyLogRecord.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/LazyLogRecord.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.LazyLogRecord" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LazyLogRecord/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LazyLogRecord" />
           <title>com.twitter.logging.LazyLogRecord</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$ALL$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$ALL$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ALL$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ALL$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ALL$" />
           <title>com.twitter.logging.Level.ALL</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$CRITICAL$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$CRITICAL$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$CRITICAL$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$CRITICAL$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$CRITICAL$" />
           <title>com.twitter.logging.Level.CRITICAL</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$DEBUG$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$DEBUG$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$DEBUG$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$DEBUG$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$DEBUG$" />
           <title>com.twitter.logging.Level.DEBUG</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$ERROR$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$ERROR$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ERROR$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ERROR$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ERROR$" />
           <title>com.twitter.logging.Level.ERROR</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$FATAL$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$FATAL$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$FATAL$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$FATAL$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$FATAL$" />
           <title>com.twitter.logging.Level.FATAL</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$INFO$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$INFO$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$INFO$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$INFO$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$INFO$" />
           <title>com.twitter.logging.Level.INFO</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$OFF$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$OFF$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$OFF$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$OFF$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$OFF$" />
           <title>com.twitter.logging.Level.OFF</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$TRACE$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$TRACE$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$TRACE$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$TRACE$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$TRACE$" />
           <title>com.twitter.logging.Level.TRACE</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$$WARNING$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$$WARNING$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$WARNING$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$WARNING$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$WARNING$" />
           <title>com.twitter.logging.Level.WARNING</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$" />
           <title>com.twitter.logging.Level</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Level.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Level.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level" />
           <title>com.twitter.logging.Level</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Logger$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Logger$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Logger$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger$" />
           <title>com.twitter.logging.Logger</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Logger.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Logger.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Logger" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger" />
           <title>com.twitter.logging.Logger</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/LoggingException.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/LoggingException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.LoggingException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LoggingException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LoggingException" />
           <title>com.twitter.logging.LoggingException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Daily$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Daily$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Daily$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Daily$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Daily$" />
           <title>com.twitter.logging.Policy.Daily</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Hourly$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Hourly$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Hourly$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Hourly$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Hourly$" />
           <title>com.twitter.logging.Policy.Hourly</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Never$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Never$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Never$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Never$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Never$" />
           <title>com.twitter.logging.Policy.Never</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Policy$$SigHup$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Policy$$SigHup$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$SigHup$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$SigHup$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$SigHup$" />
           <title>com.twitter.logging.Policy.SigHup</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Weekly.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Policy$$Weekly.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Weekly" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Weekly/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Weekly" />
           <title>com.twitter.logging.Policy.Weekly</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Policy$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Policy$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$" />
           <title>com.twitter.logging.Policy</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/Policy.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/Policy.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy" />
           <title>com.twitter.logging.Policy</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/ScribeHandler$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/ScribeHandler$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler$" />
           <title>com.twitter.logging.ScribeHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/ScribeHandler.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/ScribeHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler" />
           <title>com.twitter.logging.ScribeHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/StringHandler.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/StringHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.StringHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.StringHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.StringHandler" />
           <title>com.twitter.logging.StringHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/SyslogFormatter.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/SyslogFormatter.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFormatter" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFormatter/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFormatter" />
           <title>com.twitter.logging.SyslogFormatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/SyslogFuture$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/SyslogFuture$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFuture$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFuture$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFuture$" />
           <title>com.twitter.logging.SyslogFuture</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/SyslogHandler$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/SyslogHandler$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler$" />
           <title>com.twitter.logging.SyslogHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/SyslogHandler.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/SyslogHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler" />
           <title>com.twitter.logging.SyslogHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/ThrottledHandler.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/ThrottledHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ThrottledHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ThrottledHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ThrottledHandler" />
           <title>com.twitter.logging.ThrottledHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/BareFormatterConfig$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/BareFormatterConfig$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.BareFormatterConfig$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BareFormatterConfig$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BareFormatterConfig$" />
           <title>com.twitter.logging.config.BareFormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/BasicFormatterConfig$.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/BasicFormatterConfig$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.BasicFormatterConfig$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BasicFormatterConfig$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BasicFormatterConfig$" />
           <title>com.twitter.logging.config.BasicFormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/ConsoleHandlerConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/ConsoleHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.ConsoleHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ConsoleHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ConsoleHandlerConfig" />
           <title>com.twitter.logging.config.ConsoleHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/FileHandlerConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/FileHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.FileHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FileHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FileHandlerConfig" />
           <title>com.twitter.logging.config.FileHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/FormatterConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/FormatterConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.FormatterConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FormatterConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FormatterConfig" />
           <title>com.twitter.logging.config.FormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/HandlerConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/HandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.HandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.HandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.HandlerConfig" />
           <title>com.twitter.logging.config.HandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/LoggerConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/LoggerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.LoggerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.LoggerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.LoggerConfig" />
           <title>com.twitter.logging.config.LoggerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/ScribeHandlerConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/ScribeHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.ScribeHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ScribeHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ScribeHandlerConfig" />
           <title>com.twitter.logging.config.ScribeHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/SyslogFormatterConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/SyslogFormatterConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogFormatterConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogFormatterConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogFormatterConfig" />
           <title>com.twitter.logging.config.SyslogFormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/SyslogHandlerConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/SyslogHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogHandlerConfig" />
           <title>com.twitter.logging.config.SyslogHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/ThrottledHandlerConfig.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/ThrottledHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.ThrottledHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ThrottledHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ThrottledHandlerConfig" />
           <title>com.twitter.logging.config.ThrottledHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/config/package.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/config/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.package" />
           <title>com.twitter.logging.config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/logging/package.html
+++ b/util-logging/target/doc/main/api/com/twitter/logging/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package" />
           <title>com.twitter.logging</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/com/twitter/package.html
+++ b/util-logging/target/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/index.html
+++ b/util-logging/target/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package" />
           <title>util-logging 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/doc/main/api/package.html
+++ b/util-logging/target/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/package.html
+++ b/util-logging/target/site/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/BareFormatter$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/BareFormatter$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.BareFormatter$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BareFormatter$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BareFormatter$" />
           <title>com.twitter.logging.BareFormatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/BasicFormatter$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/BasicFormatter$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.BasicFormatter$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BasicFormatter$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.BasicFormatter$" />
           <title>com.twitter.logging.BasicFormatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/ConsoleHandler.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/ConsoleHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ConsoleHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ConsoleHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ConsoleHandler" />
           <title>com.twitter.logging.ConsoleHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/FileHandler.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/FileHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.FileHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.FileHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.FileHandler" />
           <title>com.twitter.logging.FileHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Formatter.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Formatter.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Formatter" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Formatter/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Formatter" />
           <title>com.twitter.logging.Formatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Handler.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Handler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Handler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Handler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Handler" />
           <title>com.twitter.logging.Handler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/LazyLogRecord.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/LazyLogRecord.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.LazyLogRecord" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LazyLogRecord/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LazyLogRecord" />
           <title>com.twitter.logging.LazyLogRecord</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$ALL$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$ALL$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ALL$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ALL$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ALL$" />
           <title>com.twitter.logging.Level.ALL</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$CRITICAL$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$CRITICAL$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$CRITICAL$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$CRITICAL$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$CRITICAL$" />
           <title>com.twitter.logging.Level.CRITICAL</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$DEBUG$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$DEBUG$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$DEBUG$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$DEBUG$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$DEBUG$" />
           <title>com.twitter.logging.Level.DEBUG</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$ERROR$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$ERROR$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ERROR$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ERROR$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$ERROR$" />
           <title>com.twitter.logging.Level.ERROR</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$FATAL$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$FATAL$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$FATAL$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$FATAL$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$FATAL$" />
           <title>com.twitter.logging.Level.FATAL</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$INFO$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$INFO$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$INFO$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$INFO$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$INFO$" />
           <title>com.twitter.logging.Level.INFO</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$OFF$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$OFF$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$OFF$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$OFF$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$OFF$" />
           <title>com.twitter.logging.Level.OFF</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$TRACE$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$TRACE$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$TRACE$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$TRACE$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$TRACE$" />
           <title>com.twitter.logging.Level.TRACE</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$WARNING$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$$WARNING$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$$WARNING$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$WARNING$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$$WARNING$" />
           <title>com.twitter.logging.Level.WARNING</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level$" />
           <title>com.twitter.logging.Level</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Level.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Level.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Level" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Level" />
           <title>com.twitter.logging.Level</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Logger$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Logger$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Logger$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger$" />
           <title>com.twitter.logging.Logger</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Logger.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Logger.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Logger" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Logger" />
           <title>com.twitter.logging.Logger</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/LoggingException.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/LoggingException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.LoggingException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LoggingException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.LoggingException" />
           <title>com.twitter.logging.LoggingException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Daily$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Daily$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Daily$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Daily$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Daily$" />
           <title>com.twitter.logging.Policy.Daily</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Hourly$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Hourly$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Hourly$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Hourly$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Hourly$" />
           <title>com.twitter.logging.Policy.Hourly</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Never$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Never$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Never$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Never$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Never$" />
           <title>com.twitter.logging.Policy.Never</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$SigHup$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$SigHup$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$SigHup$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$SigHup$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$SigHup$" />
           <title>com.twitter.logging.Policy.SigHup</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Weekly.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$$Weekly.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Weekly" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Weekly/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$$Weekly" />
           <title>com.twitter.logging.Policy.Weekly</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Policy$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy$" />
           <title>com.twitter.logging.Policy</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/Policy.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/Policy.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.Policy" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.Policy" />
           <title>com.twitter.logging.Policy</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/ScribeHandler$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/ScribeHandler$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler$" />
           <title>com.twitter.logging.ScribeHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/ScribeHandler.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/ScribeHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ScribeHandler" />
           <title>com.twitter.logging.ScribeHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/StringHandler.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/StringHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.StringHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.StringHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.StringHandler" />
           <title>com.twitter.logging.StringHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogFormatter.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogFormatter.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFormatter" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFormatter/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFormatter" />
           <title>com.twitter.logging.SyslogFormatter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogFuture$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogFuture$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFuture$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFuture$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogFuture$" />
           <title>com.twitter.logging.SyslogFuture</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogHandler$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogHandler$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler$" />
           <title>com.twitter.logging.SyslogHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogHandler.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/SyslogHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.SyslogHandler" />
           <title>com.twitter.logging.SyslogHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/ThrottledHandler.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/ThrottledHandler.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.ThrottledHandler" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ThrottledHandler/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.ThrottledHandler" />
           <title>com.twitter.logging.ThrottledHandler</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/BareFormatterConfig$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/BareFormatterConfig$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.BareFormatterConfig$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BareFormatterConfig$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BareFormatterConfig$" />
           <title>com.twitter.logging.config.BareFormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/BasicFormatterConfig$.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/BasicFormatterConfig$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.BasicFormatterConfig$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BasicFormatterConfig$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.BasicFormatterConfig$" />
           <title>com.twitter.logging.config.BasicFormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/ConsoleHandlerConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/ConsoleHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.ConsoleHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ConsoleHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ConsoleHandlerConfig" />
           <title>com.twitter.logging.config.ConsoleHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/FileHandlerConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/FileHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.FileHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FileHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FileHandlerConfig" />
           <title>com.twitter.logging.config.FileHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/FormatterConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/FormatterConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.FormatterConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FormatterConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.FormatterConfig" />
           <title>com.twitter.logging.config.FormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/HandlerConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/HandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.HandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.HandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.HandlerConfig" />
           <title>com.twitter.logging.config.HandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/LoggerConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/LoggerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.LoggerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.LoggerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.LoggerConfig" />
           <title>com.twitter.logging.config.LoggerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/ScribeHandlerConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/ScribeHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.ScribeHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ScribeHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ScribeHandlerConfig" />
           <title>com.twitter.logging.config.ScribeHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/SyslogFormatterConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/SyslogFormatterConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogFormatterConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogFormatterConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogFormatterConfig" />
           <title>com.twitter.logging.config.SyslogFormatterConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/SyslogHandlerConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/SyslogHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.SyslogHandlerConfig" />
           <title>com.twitter.logging.config.SyslogHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/ThrottledHandlerConfig.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/ThrottledHandlerConfig.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.ThrottledHandlerConfig" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ThrottledHandlerConfig/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.ThrottledHandlerConfig" />
           <title>com.twitter.logging.config.ThrottledHandlerConfig</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/config/package.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/config/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.config.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.config.package" />
           <title>com.twitter.logging.config</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/logging/package.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/logging/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package" />
           <title>com.twitter.logging</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/com/twitter/package.html
+++ b/util-logging/target/site/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/index.html
+++ b/util-logging/target/site/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package" />
           <title>util-logging 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/doc/main/api/package.html
+++ b/util-logging/target/site/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-logging/target/site/index.html
+++ b/util-logging/target/site/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.logging.package" />
-  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package/" />
+  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.logging.package" />
 <title>util-logging</title>
 </head>
 <body>

--- a/util-reflect/target/doc/main/api/com/package.html
+++ b/util-reflect/target/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/package.html
+++ b/util-reflect/target/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/package.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/reflect/AbstractProxyFactory.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/reflect/AbstractProxyFactory.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.AbstractProxyFactory" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.AbstractProxyFactory/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.AbstractProxyFactory" />
           <title>com.twitter.util.reflect.AbstractProxyFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/reflect/MethodCall.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/reflect/MethodCall.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.MethodCall" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.MethodCall/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.MethodCall" />
           <title>com.twitter.util.reflect.MethodCall</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/reflect/NonexistentTargetException.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/reflect/NonexistentTargetException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.NonexistentTargetException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.NonexistentTargetException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.NonexistentTargetException" />
           <title>com.twitter.util.reflect.NonexistentTargetException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/reflect/Proxy$.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/reflect/Proxy$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.Proxy$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.Proxy$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.Proxy$" />
           <title>com.twitter.util.reflect.Proxy</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/reflect/ProxyFactory$.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/reflect/ProxyFactory$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory$" />
           <title>com.twitter.util.reflect.ProxyFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/reflect/ProxyFactory.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/reflect/ProxyFactory.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory" />
           <title>com.twitter.util.reflect.ProxyFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/com/twitter/util/reflect/package.html
+++ b/util-reflect/target/doc/main/api/com/twitter/util/reflect/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
           <title>com.twitter.util.reflect</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/index.html
+++ b/util-reflect/target/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
           <title>util-reflect 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/doc/main/api/package.html
+++ b/util-reflect/target/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/package.html
+++ b/util-reflect/target/site/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/package.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/package.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/AbstractProxyFactory.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/AbstractProxyFactory.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.AbstractProxyFactory" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.AbstractProxyFactory/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.AbstractProxyFactory" />
           <title>com.twitter.util.reflect.AbstractProxyFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/MethodCall.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/MethodCall.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.MethodCall" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.MethodCall/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.MethodCall" />
           <title>com.twitter.util.reflect.MethodCall</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/NonexistentTargetException.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/NonexistentTargetException.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.NonexistentTargetException" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.NonexistentTargetException/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.NonexistentTargetException" />
           <title>com.twitter.util.reflect.NonexistentTargetException</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/Proxy$.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/Proxy$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.Proxy$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.Proxy$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.Proxy$" />
           <title>com.twitter.util.reflect.Proxy</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/ProxyFactory$.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/ProxyFactory$.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory$" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory$/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory$" />
           <title>com.twitter.util.reflect.ProxyFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/ProxyFactory.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/ProxyFactory.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.ProxyFactory" />
           <title>com.twitter.util.reflect.ProxyFactory</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/package.html
+++ b/util-reflect/target/site/doc/main/api/com/twitter/util/reflect/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
           <title>com.twitter.util.reflect</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/index.html
+++ b/util-reflect/target/site/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
           <title>util-reflect 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/doc/main/api/package.html
+++ b/util-reflect/target/site/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-reflect/target/site/index.html
+++ b/util-reflect/target/site/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
-  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package/" />
+  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.reflect.package" />
 <title>util-reflect</title>
 </head>
 <body>

--- a/util-thrift/target/doc/main/api/com/package.html
+++ b/util-thrift/target/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/com/twitter/package.html
+++ b/util-thrift/target/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/com/twitter/util/BinaryThriftSerializer.html
+++ b/util-thrift/target/doc/main/api/com/twitter/util/BinaryThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.BinaryThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BinaryThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BinaryThriftSerializer" />
           <title>com.twitter.util.BinaryThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/com/twitter/util/CompactThriftSerializer.html
+++ b/util-thrift/target/doc/main/api/com/twitter/util/CompactThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.CompactThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CompactThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CompactThriftSerializer" />
           <title>com.twitter.util.CompactThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/com/twitter/util/JsonThriftSerializer.html
+++ b/util-thrift/target/doc/main/api/com/twitter/util/JsonThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.JsonThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JsonThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JsonThriftSerializer" />
           <title>com.twitter.util.JsonThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/com/twitter/util/ThriftSerializer.html
+++ b/util-thrift/target/doc/main/api/com/twitter/util/ThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.ThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ThriftSerializer" />
           <title>com.twitter.util.ThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/com/twitter/util/package.html
+++ b/util-thrift/target/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/index.html
+++ b/util-thrift/target/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>util-thrift 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/doc/main/api/package.html
+++ b/util-thrift/target/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/com/package.html
+++ b/util-thrift/target/site/doc/main/api/com/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.package" />
           <title>com</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/com/twitter/package.html
+++ b/util-thrift/target/site/doc/main/api/com/twitter/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.package" />
           <title>com.twitter</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/com/twitter/util/BinaryThriftSerializer.html
+++ b/util-thrift/target/site/doc/main/api/com/twitter/util/BinaryThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.BinaryThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BinaryThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.BinaryThriftSerializer" />
           <title>com.twitter.util.BinaryThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/com/twitter/util/CompactThriftSerializer.html
+++ b/util-thrift/target/site/doc/main/api/com/twitter/util/CompactThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.CompactThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CompactThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.CompactThriftSerializer" />
           <title>com.twitter.util.CompactThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/com/twitter/util/JsonThriftSerializer.html
+++ b/util-thrift/target/site/doc/main/api/com/twitter/util/JsonThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.JsonThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JsonThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.JsonThriftSerializer" />
           <title>com.twitter.util.JsonThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/com/twitter/util/ThriftSerializer.html
+++ b/util-thrift/target/site/doc/main/api/com/twitter/util/ThriftSerializer.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.ThriftSerializer" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ThriftSerializer/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.ThriftSerializer" />
           <title>com.twitter.util.ThriftSerializer</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/com/twitter/util/package.html
+++ b/util-thrift/target/site/doc/main/api/com/twitter/util/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>com.twitter.util</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/index.html
+++ b/util-thrift/target/site/doc/main/api/index.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>util-thrift 1.8.6-SNAPSHOT API</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/doc/main/api/package.html
+++ b/util-thrift/target/site/doc/main/api/package.html
@@ -3,7 +3,7 @@
 <html>
         <head>
           <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+          <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
           <title>_root_</title>
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           

--- a/util-thrift/target/site/index.html
+++ b/util-thrift/target/site/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="refresh" content="0; url=https://twitter.github.io/util/docs/#com.twitter.util.package" />
-  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package/" />
+  <link rel="canonical" href="https://twitter.github.io/util/docs/#com.twitter.util.package" />
 <title>util-thrift</title>
 </head>
 <body>


### PR DESCRIPTION
Problem

We're still hosting old versions of the API docs (from before Unidoc). These
out-of-date versions are appearing before the current version in search results.

Solution

I've written a small script to add the appropriate meta redirect and canonical
link to each page in the older versions (which are not touched by the updatedocs
script).

Result

I ran the automatically generated links through a little PhantomJS test, and the
following are broken:

https://twitter.github.io/util/docs/#com.twitter.concurrent.Channel
https://twitter.github.io/util/docs/#com.twitter.concurrent.ChannelSource
https://twitter.github.io/util/docs/#com.twitter.concurrent.Observer
https://twitter.github.io/util/docs/#com.twitter.concurrent.ObserverSource
https://twitter.github.io/util/docs/#com.twitter.logging.BasicFormatter$
https://twitter.github.io/util/docs/#com.twitter.logging.config.BasicFormatterConfig$
https://twitter.github.io/util/docs/#com.twitter.util.Eval$$CompilerException
https://twitter.github.io/util/docs/#com.twitter.util.Eval$$StringCompiler
https://twitter.github.io/util/docs/#com.twitter.util.Locals$
https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$
https://twitter.github.io/util/docs/#com.twitter.util.MapMaker$$Config
https://twitter.github.io/util/docs/#com.twitter.util.SavedLocal
https://twitter.github.io/util/docs/#com.twitter.util.SavedLocals
https://twitter.github.io/util/docs/#com.twitter.util.StreamHelper$
https://twitter.github.io/util/docs/#com.twitter.util.TimeMath$
https://twitter.github.io/util/docs/#com.twitter.util.TimeOverflowException
https://twitter.github.io/util/docs/#com.twitter.util.TryLike

With the exception of CompilerException, these actually don't exist now, so I
think it makes sense simply to leave the links broken.
