### PR TITLE
Proposal to allow eval to be configured with a custom CP

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt.Keys._
 import sbt._
 
 object Util extends Build {
-  val libVersion = "6.19.0"
+  val libVersion = "6.19.1-SNAPSHOT"
   val zkVersion = "3.3.4"
   val zkDependency = "org.apache.zookeeper" % "zookeeper" % zkVersion excludeAll(
     ExclusionRule("com.sun.jdmk", "jmxtools"),


### PR DESCRIPTION
Problem:
For whatever reason the classpath from this.getClass.getClassLoader was quite empty during the test-run within maven ( only the jdk jars + surefire + jacoco ones were found o.O ).
It might be due to the fact that things are launched in a fork thread (ForkJoinPool used by test AFAICT).
So when I was using custom import (even scala of course), classes were not found and thus the file failed to compile.

Solution:
Added an extra parameter to Eval's constructor that takes a function producing a `List[List[String]]` (keeping the signature of `getClasspath`). 
Two implementations provided:
* the original policy using the classpath accessible relatively to the Eval.class
* another one using the sys property java.class.path to use the whole classpath
The no-parameter constructor has been updated to use the original strategy for backward-compat.

Result:
Now, we can use the full classpath detected by the jvm, however, using this way we loose the "executable-jar" functionality when the direct classloader has only one jar.

![selfie-7](http://i.imgur.com/IdjbmeW.png)
