### PR TITLE
Allow manual flushing of a batcher with flushBatch method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ Next Version
 
 New Features:
   * util-core: Add Future.collect() method that collects over Map's values
+  * util-core: Add method .flushBatch() to batched future returned by Future.batched()
+               that immediately initiates processing of all remaining queued requests
   * util-stats: Create a new module, `util-stats` to move `finagle-core`
                 StatsReceivers to.  They retain the `com.twitter.finagle`
                 namespace to ease the transition.
@@ -20,6 +22,7 @@ Deprecation:
 API Changes:
   * util-core: Rename Buf._.Unsafe to Buf._.Owned and Buf._.Copied to Buf._.Shared
   * util-core: Remove the com.twitter.util.repository package
+  * util-core: Change return type of Future.batched() to com.twitter.util.Batcher
 
 Java Compatibility:
   * util-app: Flaggable is now an abstract class for Java compatibility
@@ -56,7 +59,7 @@ Bug Fixes:
 
 Deprecation:
   * util-core: Add deprecation of RingBuffer to changelog
-  * util-core: Removed IVar and IVarField 
+  * util-core: Removed IVar and IVarField
 
 Documentation:
   * util-core: Clarify Scaladoc of `Promise.attached`
@@ -65,7 +68,7 @@ Documentation:
 
 New Features:
   * util-app: Add App registration
-  * util-cache Add asynchronous cache with TTL 
+  * util-cache Add asynchronous cache with TTL
   * util-core: Add `Activity.future`
 
 Package factoring:

--- a/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -98,6 +98,14 @@ private[util] class BatchExecutor[In, Out](
     promise
   }
 
+  def flushNow(): Unit = {
+    val doAfter = synchronized {
+      flushBatch()
+    }
+
+    doAfter()
+  }
+
   def scheduleFlushIfNecessary() {
     if (timeThreshold < Duration.Top && scheduled.isEmpty)
       scheduled = Some(new ScheduledFlush(timeThreshold, timer))

--- a/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -98,6 +98,7 @@ private[util] class BatchExecutor[In, Out](
     promise
   }
 
+  /** Immediately processes all unprocessed requests */
   def flushNow(): Unit = {
     val doAfter = synchronized {
       flushBatch()

--- a/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -22,9 +22,8 @@ import scala.collection.mutable
  * - Rather than having separate sizeThreshold and sizePercentile parameters,
  *   just have a single call-by-name sizeThreshold parameter, and let the
  *   caller implement whatever logic they want to compute the next batch size.
- * - Return an instance of a new class (Batcher?) which extends
- *   `In => Future[Out]`. Could support things like querying the queue size,
- *   forcing a flush, attaching callbacks to flush operations, etc.
+ * - Add more functionality to class Batcher. Could support things like querying the queue size,
+ *   attaching callbacks to flush operations, etc.
  */
 private[util] class BatchExecutor[In, Out](
   sizeThreshold: Int,

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -6,10 +6,11 @@ class Batcher[In, Out] private[util](
 )(
   implicit timer: Timer
 ) extends Function1[In, Future[Out]] { batcher =>
-  /** Enqueues requests for a batched [[com.twitter.util.Future]]
-    *
-    * Processes all enqueued requests after the batch size is reached
-    */
+  /**
+   * Enqueues requests for a batched [[com.twitter.util.Future]]
+   *
+   * Processes all enqueued requests after the batch size is reached
+   */
   def apply(t: In): Future[Out] = executor.enqueue(t)
 
   /** Immediately processes all unprocessed requests */

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -1,27 +1,17 @@
 package com.twitter.util
 
-import java.util.logging.{Level, Logger}
-
-import scala.collection.mutable
-
-/** Provides a clean, lightweight interface for controlling a BatchExecutor
-  *
-  * @constructor create a new Batcher for a BatchExecutor
-  * @param executor the BatchExector to be used
-  */
-class Batcher[In, Out](
+/** Provides a clean, lightweight interface for working with batched Futures */
+private[util] class Batcher[In, Out](
   executor: BatchExecutor[In, Out]
 )(
   implicit timer: Timer
 ) extends Function1[In, Future[Out]] { batcher =>
-  import java.util.logging.Level.WARNING
-
-  /** Enqueues requests for the BatchExecutor */
+  /** Enqueues requests for a batched Future */
   def apply(t: In): Future[Out] = executor.enqueue(t)
 
   /** Immediately processes all unprocessed requests */
   def flushBatch(): Unit = {
-    val doAfter = synchronized {
+    val doAfter = executor.synchronized {
       executor.flushBatch()
     }
 

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -1,0 +1,28 @@
+package com.twitter.util
+
+import java.util.logging.{Level, Logger}
+
+import scala.collection.mutable
+
+class Batcher[In, Out](
+  sizeThreshold: Int,
+  timeThreshold: Duration = Duration.Top,
+  sizePercentile: => Float = 1.0f,
+  f: Seq[In] => Future[Seq[Out]]
+)(
+  implicit timer: Timer
+) extends Function1[In, Future[Out]] { batcher =>
+  import java.util.logging.Level.WARNING
+
+  val executor = new BatchExecutor[In, Out](sizeThreshold, timeThreshold, sizePercentile, f)
+
+  def apply(t: In): Future[Out] = executor.enqueue(t)
+
+  def flushBatch() = {
+    val doAfter = synchronized {
+      executor.flushBatch()
+    }
+
+    doAfter()
+  }
+}

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -4,21 +4,23 @@ import java.util.logging.{Level, Logger}
 
 import scala.collection.mutable
 
+/** Provides a clean, lightweight interface for controlling a BatchExecutor
+  *
+  * @constructor create a new Batcher for a BatchExecutor
+  * @param executor the BatchExector to be used
+  */
 class Batcher[In, Out](
-  sizeThreshold: Int,
-  timeThreshold: Duration = Duration.Top,
-  sizePercentile: => Float = 1.0f,
-  f: Seq[In] => Future[Seq[Out]]
+  executor: BatchExecutor[In, Out]
 )(
   implicit timer: Timer
 ) extends Function1[In, Future[Out]] { batcher =>
   import java.util.logging.Level.WARNING
 
-  val executor = new BatchExecutor[In, Out](sizeThreshold, timeThreshold, sizePercentile, f)
-
+  /** Enqueues requests for the BatchExecutor */
   def apply(t: In): Future[Out] = executor.enqueue(t)
 
-  def flushBatch() = {
+  /** Immediately processes all unprocessed requests */
+  def flushBatch(): Unit = {
     val doAfter = synchronized {
       executor.flushBatch()
     }

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -1,11 +1,11 @@
 package com.twitter.util
 
-/** Provides a clean, lightweight interface for working with a batched [[com.twitter.util.Future]] */
+/** Provides an interface for working with a batched [[com.twitter.util.Future]] */
 class Batcher[In, Out] private[util](
   executor: BatchExecutor[In, Out]
 )(
   implicit timer: Timer
-) extends Function1[In, Future[Out]] { batcher =>
+) extends (In => Future[Out]) { batcher =>
   /**
    * Enqueues requests for a batched [[com.twitter.util.Future]]
    *

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -1,14 +1,14 @@
 package com.twitter.util
 
-/** Provides a clean, lightweight interface for working with batched Futures */
+/** Provides a clean, lightweight interface for working with a batched [[com.twitter.util.Future]] */
 class Batcher[In, Out] private[util](
   executor: BatchExecutor[In, Out]
 )(
   implicit timer: Timer
 ) extends Function1[In, Future[Out]] { batcher =>
-  /** Enqueues requests for a batched Future
+  /** Enqueues requests for a batched [[com.twitter.util.Future]]
     *
-    * When the batch size is reached, all enqueued requests are processed
+    * Processes all enqueued requests after the batch size is reached
     */
   def apply(t: In): Future[Out] = executor.enqueue(t)
 

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -14,7 +14,5 @@ class Batcher[In, Out] private[util](
   def apply(t: In): Future[Out] = executor.enqueue(t)
 
   /** Immediately processes all unprocessed requests */
-  def flushBatch(): Unit = {
-    executor.flushNow()
-  }
+  def flushBatch(): Unit = executor.flushNow()
 }

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -1,12 +1,15 @@
 package com.twitter.util
 
 /** Provides a clean, lightweight interface for working with batched Futures */
-private[util] class Batcher[In, Out](
+class Batcher[In, Out] private[util](
   executor: BatchExecutor[In, Out]
 )(
   implicit timer: Timer
 ) extends Function1[In, Future[Out]] { batcher =>
-  /** Enqueues requests for a batched Future */
+  /** Enqueues requests for a batched Future
+    *
+    * When the batch size is reached, all enqueued requests are processed
+    */
   def apply(t: In): Future[Out] = executor.enqueue(t)
 
   /** Immediately processes all unprocessed requests */

--- a/util-core/src/main/scala/com/twitter/util/Batcher.scala
+++ b/util-core/src/main/scala/com/twitter/util/Batcher.scala
@@ -15,10 +15,6 @@ class Batcher[In, Out] private[util](
 
   /** Immediately processes all unprocessed requests */
   def flushBatch(): Unit = {
-    val doAfter = executor.synchronized {
-      executor.flushBatch()
-    }
-
-    doAfter()
+    executor.flushNow()
   }
 }

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -533,6 +533,10 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
    *       ...
    *     }
    *
+   * To force the batcher to immediately process all unprocessed requests:
+   *
+   *     batcher.flushBatch
+   *
    * A batcher's size can be controlled at runtime with the `sizePercentile`
    * function argument. This function returns a float between 0.0 and 1.0,
    * representing the fractional size of the `sizeThreshold` that should be
@@ -546,8 +550,8 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
     f: Seq[In] => Future[Seq[Out]]
   )(
     implicit timer: Timer
-  ): In => Future[Out] = {
-    new BatchExecutor[In, Out](sizeThreshold, timeThreshold, sizePercentile, f)
+  ): Batcher[In, Out] = {
+    new Batcher[In, Out](sizeThreshold, timeThreshold, sizePercentile, f)
   }
 }
 

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -535,7 +535,7 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
    *
    * To force the batcher to immediately process all unprocessed requests:
    *
-   *     batcher.flushBatch
+   *     batcher.flushBatch()
    *
    * A batcher's size can be controlled at runtime with the `sizePercentile`
    * function argument. This function returns a float between 0.0 and 1.0,
@@ -551,7 +551,7 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
   )(
     implicit timer: Timer
   ): Batcher[In, Out] = {
-    new Batcher[In, Out](sizeThreshold, timeThreshold, sizePercentile, f)
+    new Batcher[In, Out](new BatchExecutor[In, Out](sizeThreshold, timeThreshold, sizePercentile, f))
   }
 }
 

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -5,7 +5,7 @@ import com.twitter.conversions.time._
 import java.util.concurrent.ConcurrentLinkedQueue
 import org.junit.runner.RunWith
 import org.mockito.Matchers.any
-import org.mockito.Mockito.{never, verify, when}
+import org.mockito.Mockito.{never, verify, when, times}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalacheck.{Gen, Arbitrary}
@@ -312,12 +312,59 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
           val f = mock[Seq[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(4)(f)
 
-          when(f.apply(Seq(1,2,3))) thenReturn(Future.value(result))
           batcher(1)
           batcher(2)
           batcher(3)
           batcher.flushBatch
+
           verify(f).apply(Seq(1,2,3))
+        }
+
+        "only execute for remaining items when flushBatch is called after size threshold is reached" in {
+          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val batcher = Future.batched(4)(f)
+
+          batcher(1)
+          batcher(2)
+          batcher(3)
+          batcher(4)
+          batcher(5)
+          batcher.flushBatch
+
+          verify(f, times(1)).apply(Seq(1,2,3,4))
+          verify(f, times(1)).apply(Seq(5))
+        }
+
+        "only execute once when time threshold is reached after flushBatch is called" in {
+          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val batcher = Future.batched(4, 3.seconds)(f)
+
+          Time.withCurrentTimeFrozen { control =>
+            batcher(1)
+            batcher(2)
+            batcher(3)
+            batcher.flushBatch
+            control.advance(10.seconds)
+            timer.tick()
+
+            verify(f, times(1)).apply(Seq(1, 2, 3))
+          }
+        }
+
+        "only execute once when time threshold is reached before flushBatch is called" in {
+          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val batcher = Future.batched(4, 3.seconds)(f)
+
+          Time.withCurrentTimeFrozen { control =>
+            batcher(1)
+            batcher(2)
+            batcher(3)
+            control.advance(10.seconds)
+            timer.tick()
+            batcher.flushBatch
+
+            verify(f, times(1)).apply(Seq(1, 2, 3))
+          }
         }
 
         "propagates results" in {
@@ -1578,7 +1625,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
       f mustProduce Throw(e)
       assert(task.isCancelled)
     }
-    
+
     "Return Future.Done for durations <= 0" in {
       implicit val timer = new MockTimer
       assert(Future.sleep(Duration.Zero) eq Future.Done)

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -315,7 +315,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
           batcher(1)
           batcher(2)
           batcher(3)
-          batcher.flushBatch
+          batcher.flushBatch()
 
           verify(f).apply(Seq(1,2,3))
         }
@@ -329,7 +329,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
           batcher(3)
           batcher(4)
           batcher(5)
-          batcher.flushBatch
+          batcher.flushBatch()
 
           verify(f, times(1)).apply(Seq(1,2,3,4))
           verify(f, times(1)).apply(Seq(5))
@@ -343,7 +343,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
             batcher(1)
             batcher(2)
             batcher(3)
-            batcher.flushBatch
+            batcher.flushBatch()
             control.advance(10.seconds)
             timer.tick()
 
@@ -361,7 +361,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
             batcher(3)
             control.advance(10.seconds)
             timer.tick()
-            batcher.flushBatch
+            batcher.flushBatch()
 
             verify(f, times(1)).apply(Seq(1, 2, 3))
           }

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -329,9 +329,9 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
           batcher(3)
           batcher(4)
           batcher(5)
-          batcher.flushBatch()
-
           verify(f, times(1)).apply(Seq(1,2,3,4))
+
+          batcher.flushBatch()
           verify(f, times(1)).apply(Seq(5))
         }
 

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -308,6 +308,18 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
           }
         }
 
+        "execute when flushBatch is called" in {
+          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val batcher = Future.batched(4)(f)
+
+          when(f.apply(Seq(1,2,3))) thenReturn(Future.value(result))
+          batcher(1)
+          batcher(2)
+          batcher(3)
+          batcher.flushBatch
+          verify(f).apply(Seq(1,2,3))
+        }
+
         "propagates results" in {
           val f = mock[Seq[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3)(f)


### PR DESCRIPTION
Implements part of a TODO item listed in comments in BatchExecutor.scala

Future.batched now returns an instance of class Batcher, which has the added method flushBatch to allow manual flushing/execution of remaining items in the batcher.