### PR TITLE
Fix Scala and Java versions in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ scala:
 
 jdk:
   - oraclejdk7
+  - oraclejdk8
   - openjdk7
 
 before_script:


### PR DESCRIPTION
Problem

We no longer intend to support Java 6, and it should not be included in the
Travis config. Also the use of `+test` in the SBT command causes the tests to
be run against all Scala versions in the SBT config, not Travis's version.

Solution

Remove OpenJDK 6 and the plus sign in the SBT command, and add Scala 2.11.2.

Result

Tests run as intended.
