### PR TITLE
Add import to Java code to appease Scaladoc

### DIFF
--- a/util-core/src/main/java/com/twitter/util/AbstractCloseAwaitably.java
+++ b/util-core/src/main/java/com/twitter/util/AbstractCloseAwaitably.java
@@ -2,6 +2,7 @@ package com.twitter.util;
 
 import scala.runtime.BoxedUnit;
 
+import com.twitter.util.Awaitable.CanAwait;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**


### PR DESCRIPTION
Problem

Scaladoc crashes on valid code when a type that is defined in a companion
object is referred to in a Java class that implements the object's companion
trait.

Solution

Explicitly import the trait that's causing Scaladoc to fail.
