### PR TITLE
Unit test breaks in other locales

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/StorageUnit.scala
+++ b/util-core/src/main/scala/com/twitter/util/StorageUnit.scala
@@ -16,6 +16,8 @@
 
 package com.twitter.util
 
+import java.util.Locale
+
 object StorageUnit {
   val infinite = new StorageUnit(Long.MaxValue)
   val zero = new StorageUnit(0)
@@ -110,7 +112,7 @@ class StorageUnit(val bytes: Long) extends Ordered[StorageUnit] {
     if (prefixIndex < 0) {
       "%d B".format(bytes)
     } else {
-      "%.1f %ciB".format(display*bytes.signum, prefix.charAt(prefixIndex))
+      "%.1f %ciB".formatLocal(Locale.ENGLISH, display*bytes.signum, prefix.charAt(prefixIndex))
     }
   }
 }


### PR DESCRIPTION
Some locales represent floats as "12,3" instead of "12.3", so StorageUnitTest fails.
This PR forces English locale to be used when formatting storage units.
It changes code behaviour (rather than the test), but I guess it shouldn't matter that much.