### PR TITLE
Add helpers for Java 8 lambda integration

### DIFF
--- a/util-core/src/main/java/com/twitter/util/ExceptionalJavaConsumer.java
+++ b/util-core/src/main/java/com/twitter/util/ExceptionalJavaConsumer.java
@@ -1,0 +1,10 @@
+package com.twitter.util;
+
+/**
+ * Used for Java 8 interop.
+ * This is a SAM version of c.t.u.ExceptionalFunction (returning Unit/void).
+ */
+// @FunctionalInterface
+public interface ExceptionalJavaConsumer<T> {
+    public void apply(T value) throws Throwable;
+}

--- a/util-core/src/main/java/com/twitter/util/ExceptionalJavaFunction.java
+++ b/util-core/src/main/java/com/twitter/util/ExceptionalJavaFunction.java
@@ -1,0 +1,10 @@
+package com.twitter.util;
+
+/**
+ * Used for Java 8 interop.
+ * This is a SAM version of c.t.u.ExceptionalFunction.
+ */
+// @FunctionalInterface
+public interface ExceptionalJavaFunction<A,B> {
+    public B apply(A value) throws Throwable;
+}

--- a/util-core/src/main/java/com/twitter/util/JavaConsumer.java
+++ b/util-core/src/main/java/com/twitter/util/JavaConsumer.java
@@ -1,0 +1,11 @@
+package com.twitter.util;
+
+/**
+ * Used for Java 8 interop.
+ * It also exists as java.util.function.Consumer, but only from Java 8 onwards.
+ * (Since twitter util must be backwards-compatible, we cannot use j.u.f.Function)
+ */
+// @FunctionalInterface
+public interface JavaConsumer<T> {
+    public void apply(T value);
+}

--- a/util-core/src/main/java/com/twitter/util/JavaFunction.java
+++ b/util-core/src/main/java/com/twitter/util/JavaFunction.java
@@ -1,0 +1,12 @@
+package com.twitter.util;
+
+/**
+ * Used for Java 8 interop.
+ * This is a SAM version of c.t.u.Function.
+ * It also exists as java.util.function.Function, but only from Java 8 onwards.
+ * (Since twitter util must be backwards-compatible, we cannot use j.u.Function)
+ */
+// @FunctionalInterface
+public interface JavaFunction<T, R> {
+    public R apply(T value);
+}

--- a/util-core/src/main/scala/com/twitter/util/Function.scala
+++ b/util-core/src/main/scala/com/twitter/util/Function.scala
@@ -47,6 +47,58 @@ object Function {
    * Creates `() => A` function from given `Callable`.
    */
   def ofCallable[A](c: Callable[A]): () => A = () => c.call()
+
+  /**
+   * Creates a T => R from a JavaFunction. Used for easier interop
+   * between Java 8 and Twitter Util libraries.
+   */
+  def function[T, R](f: JavaFunction[T, R]) = new Function[T, R] {
+    override def apply(value: T): R = f(value)
+  }
+
+  /**
+   * Short form of `function`
+   */
+  def f[T, R](f: JavaFunction[T, R]) : Function[T, R] = function(f)
+
+  /**
+   * Creates a T => Unit from a JavaConsumer.
+   * Useful for e.g. future.onSuccess
+   */
+  def consumer[T](f: JavaConsumer[T]) = new Function[T, Unit] {
+    override def apply(value: T): Unit = f(value)
+  }
+
+  /**
+   * Short form of `consumer`
+   */
+  def c[T](f: JavaConsumer[T]) : Function[T, Unit] = consumer(f)
+
+  /**
+   * like `function`, but deals with checked exceptions as well
+   */
+  def exceptionalFunction[T, R](f: ExceptionalJavaFunction[T, R]) = new ExceptionalFunction[T, R] {
+    @throws(classOf[Throwable])
+    override def applyE(value: T): R = f(value)
+  }
+
+  /**
+   * Short form of `exceptionalFunction`
+   */
+  def xf[T, R](f: ExceptionalJavaFunction[T, R]) : ExceptionalFunction[T, R] = exceptionalFunction(f)
+
+  /**
+   * like `consumer`, but deals with checked exceptions as well
+   */
+  def exceptionalConsumer[T](f: ExceptionalJavaConsumer[T]) = new ExceptionalFunction[T, Unit] {
+    @throws(classOf[Throwable])
+    override def applyE(value: T): Unit = f(value)
+  }
+
+  /**
+   * Short form of `exceptionalConsumer`
+   */
+  def xc[T](f: ExceptionalJavaConsumer[T]) : ExceptionalFunction[T, Unit] = exceptionalConsumer(f)
 }
 
 abstract class ExceptionalFunction[-T1, +R] extends Function[T1, R] {

--- a/util-core/src/test/java/com/twitter/util/FunctionCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/util/FunctionCompilationTest.java
@@ -1,6 +1,12 @@
 package com.twitter.util;
 
 import org.junit.Test;
+import scala.runtime.BoxedUnit;
+
+import static com.twitter.util.Function.c;
+import static com.twitter.util.Function.f;
+import static com.twitter.util.Function.xc;
+import static com.twitter.util.Function.xf;
 
 /**
  * Tests are not currently run for java, but for our purposes, if the test compiles at all, it's
@@ -9,7 +15,7 @@ import org.junit.Test;
 public class FunctionCompilationTest {
 
   /** Confirm that we can extend ExceptionalFunction with applyE(). */
-  @Test
+  @Test(expected = Exception.class)
   public void testDefineWithException() {
     ExceptionalFunction<Integer, String> fun = new ExceptionalFunction<Integer, String>() {
       @Override
@@ -17,16 +23,11 @@ public class FunctionCompilationTest {
         throw new Exception("Expected");
       }
     };
-    try {
-      fun.apply(1);
-      assert false : "Should have thrown";
-    } catch (Exception e) {
-      // pass: expected
-    }
+    fun.apply(1);
   }
 
   /** Confirm that we can extend ExceptionalFunction0 with applyE(). */
-  @Test
+  @Test(expected = Exception.class)
   public void testExceptionalFunction0() {
     ExceptionalFunction0<Integer> fun = new ExceptionalFunction0<Integer>() {
       @Override
@@ -34,11 +35,66 @@ public class FunctionCompilationTest {
         throw new Exception("Expected");
       }
     };
-    try {
-      fun.apply();
-      assert false : "Should have thrown";
-    } catch (Exception e) {
-      // pass: expected
-    }
+    fun.apply();
+  }
+
+  @Test
+  public void testMakeFunctionFromLambda() {
+    Function<String,String> fun = f(new JavaFunction<String, String>() {
+      @Override
+      public String apply(String value) {
+        return value.toUpperCase();
+      }
+    });
+
+    // This syntax works in Java 8:
+    // fun = f(String::toUpperCase);
+
+    fun.apply("test");
+  }
+
+  @Test(expected = Exception.class)
+  public void testMakeExceptionalFunctionFromLambda() {
+    ExceptionalFunction<String,String> fun = xf(new ExceptionalJavaFunction<String, String>() {
+      @Override
+      public String apply(String value) throws Throwable {
+        throw new Exception("Expected");
+      }
+    });
+
+    // This syntax works in Java 8:
+    // myFun = xf(str -> { throw new Exception("Expected"); });
+
+    fun.apply("test");
+  }
+
+  @Test
+  public void testMakeUnitFunction() {
+    Function<String, BoxedUnit> fun = c(new JavaConsumer<String>() {
+      @Override
+      public void apply(String value) {
+        System.out.println(value);
+      }
+    });
+
+    // This syntax works in Java 8:
+    // fun = c(System.out::println);
+
+    fun.apply("test");
+  }
+
+  @Test(expected = Exception.class)
+  public void makeExceptionalUnitFunction() throws Exception {
+    Function<String, BoxedUnit> fun = xc(new ExceptionalJavaConsumer<String>() {
+      @Override
+      public void apply(String value) throws Exception {
+        throw new Exception("Expected");
+      }
+    });
+
+    // This syntax works in Java 8:
+    // fun = xc(value -> { throw new Exception("Expected"); });
+
+    fun.apply("test");
   }
 }


### PR DESCRIPTION
I tried to overload the "map", "flatMap" etc. methods in c.t.u.Future directly, so they could accept Java lambdas without using a converter function. But I couldn't make it compile. (Does anybody know how it can be done?)

This commit lets you write Java code that looks like this:

```java
Future.value(3)
  .flatMap(func(i -> Future.value(2*i)))
  .map(func(i -> i + 3))
  .onSuccess(cons(System.out::println));
```

or

```java
userService.getUser("john")
  .flatMap(func(u -> profileService.getProfile(u.id)))
  .map(func(Templates::renderProfile))
  .onSuccess(cons(System.out::println));
```

**Commit message:**
> The method c.t.u.Function.func converts a Java 8 lambda
> into a c.t.u.Function, which can be used in Twitter's
> functional APIs (e.g. Futures)
> 
> example:
>
>```java
> import static com.twitter.util.Function.func;
> Function<String, String> fun = func(String::toUpperCase);
> ```
>
> There is a method c.t.u.Function.exfunc that also
> deals with checked exceptions.
> 
> You often need consumers, functions of type T => Unit,
> e.g. for future.onSuccess. In these cases, you can use
> Function.cons to convert a lambda-style consumer into
> a Scala function
> 
> example:
> ```java
> Function<String, BoxedUnit> fun = cons(System.out::println);
> ```
> 
> Later, Scala 2.12 will have native support for Java 8 lambdas.
