### PR TITLE
Fix race condition in ZkAsyncSemaphore

### DIFF
--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
@@ -262,7 +262,7 @@ class ZkAsyncSemaphore(zk: ZkClient, path: String, numPermits: Int, maxWaiters: 
     path.substring(permitNodePathPrefix.length).toInt
   }
 
-  private[this] def numPermitsOf(node: ZNode): Future[Int] = {
+  private[coordination] def numPermitsOf(node: ZNode): Future[Int] = {
     node.getData().transform {
       case Return(data: ZNode.Data) =>
         try {

--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
@@ -7,8 +7,8 @@ import org.apache.zookeeper.{CreateMode, KeeperException}
 import org.apache.zookeeper.KeeperException.NoNodeException
 
 import com.twitter.concurrent.Permit
-import com.twitter.util.{Throw, Return, Future, Promise}
-import com.twitter.zk.{StateEvent, ZNode, ZkClient}
+import com.twitter.util.{Future, Promise, Return, Throw}
+import com.twitter.zk.{StateEvent, ZkClient, ZNode}
 
 /**
  * ZkAsyncSemaphore is a distributed semaphore with asynchronous execution.

--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
@@ -266,11 +266,13 @@ class ZkAsyncSemaphore(zk: ZkClient, path: String, numPermits: Int, maxWaiters: 
     node.getData().transform {
       case Return(data: ZNode.Data) =>
         try {
-          Future(new String(data.bytes, Charset.forName("UTF8")).toInt)
+          Future.value(new String(data.bytes, Charset.forName("UTF8")).toInt)
         } catch {
-          case err: NumberFormatException => Future(-1)
+          case err: NumberFormatException => Future.value(-1)
         }
-      case Throw(t: NoNodeException) => Future(-1)
+      case Throw(t: NoNodeException) =>
+        // This permit was released (i.e. after we got the list of permits).
+        Future.value(-1)
       case Throw(t) => Future.exception(t)
     }
   }

--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
@@ -270,8 +270,8 @@ class ZkAsyncSemaphore(zk: ZkClient, path: String, numPermits: Int, maxWaiters: 
         } catch {
           case err: NumberFormatException => Future(-1)
         }
-      case Throw(t) =>
-        Future(-1)
+      case Throw(t: NoNodeException) => Future(-1)
+      case Throw(t) => Future.exception(t)
     }
   }
 

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -153,7 +153,7 @@ class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertio
             Await.result(znode.delete().rescue{ case e: NoNodeException => Future.value(0) })
             Await.result(znode.create("7".getBytes))
             val permits: Future[Int] = sem.numPermitsOf(znode)
-            assert(permits.get() == 7)
+            assert(Await.result(permits) == 7)
           }
         }
 

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.JavaConverters._
 
+import org.apache.zookeeper.KeeperException.NoNodeException
 import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
 import org.junit.runner.RunWith
 import org.scalatest.WordSpec
@@ -148,8 +149,9 @@ class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertio
         "get a node's value" in {
           withClient { zk =>
             val sem = new ZkAsyncSemaphore(zk, "/aoeu/aoeu", 2)
-            val znode = ZNode(zk, "/testing/twitter/uuu")
-            znode.create("7".getBytes)
+            val znode = ZNode(zk, "/testing/twitter/node_with_data_7")
+            Await.result(znode.delete().rescue{ case e: NoNodeException => Future.value(0) })
+            Await.result(znode.create("7".getBytes))
             val permits: Future[Int] = sem.numPermitsOf(znode)
             assert(permits.get() == 7)
           }

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -11,7 +11,6 @@ import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.PrivateMethodTester
 import org.scalatest.time.{Millis, Seconds, Span}
 
 import com.twitter.concurrent.Permit
@@ -20,7 +19,7 @@ import com.twitter.util._
 import com.twitter.zk.{NativeConnector, RetryPolicy, ZkClient, ZNode}
 
 @RunWith(classOf[JUnitRunner])
-class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertions with PrivateMethodTester {
+class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertions {
 
   "ZkAsyncSemaphore" should {
 
@@ -147,21 +146,19 @@ class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertio
 
       "numPermitsOf" should {
         "get a node's value" in {
-          val numPermitsOfMethod = PrivateMethod[Future[Int]]('numPermitsOf)
           withClient { zk =>
             val sem = new ZkAsyncSemaphore(zk, "/aoeu/aoeu", 2)
             val znode = ZNode(zk, "/testing/twitter/uuu")
             znode.create("7".getBytes)
-            val permits: Future[Int] = sem invokePrivate numPermitsOfMethod(znode)
+            val permits: Future[Int] = sem.numPermitsOf(znode)
             assert(permits.get() == 7)
           }
         }
 
         "not error on NoNode" in {
-          val numPermitsOfMethod = PrivateMethod[Future[Int]]('numPermitsOf)
           withClient { zk =>
             val sem = new ZkAsyncSemaphore(zk, "/aoeu/aoeu", 2)
-            val permits: Future[Int] = sem invokePrivate numPermitsOfMethod(ZNode(zk, "/aoeu/aoeu/aoeu"))
+            val permits: Future[Int] = sem.numPermitsOf(ZNode(zk, "/aoeu/aoeu/node_that_does_not_exist"))
             Await.result(permits)
           }
         }

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -162,7 +162,7 @@ class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertio
           withClient { zk =>
             val sem = new ZkAsyncSemaphore(zk, "/aoeu/aoeu", 2)
             val permits: Future[Int] = sem invokePrivate numPermitsOfMethod(ZNode(zk, "/aoeu/aoeu/aoeu"))
-            permits.get()
+            Await.result(permits)
           }
         }
       }


### PR DESCRIPTION
Before acquiring a permit, ZkAsyncSemaphore gets the list of existing permits and then checks each permit ZNode’s data. This raised an error when one of the existing permits is released between the time the list was gotten and the data was checked. This was an issue for us because we are using ZkAsyncSemaphore in Hadoop containers. When many containers are closing while others are opening, many permits get released rapidly.

This PR changes the shard permit consensus logic to count lost existing permits as having not been seen in the first place.