### PR TITLE
Replace reference to scala.ScalaObject with scala.AnyVal

### DIFF
--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -80,7 +80,7 @@ class Eval(target: Option[File]) {
   }
 
   private lazy val libPath = try {
-    classPathOfClass("scala.ScalaObject")
+    classPathOfClass("scala.AnyVal")
   } catch {
     case e: Throwable =>
       throw new RuntimeException("Unable to load scala base object from classpath (scala-library jar is missing?)", e)


### PR DESCRIPTION
Currently, `util-eval` seems not to be usable in Scala 2.11, since `ScalaObject` was deprecated in 2.10.

Replacing the reference to `ScalaObject` with `AnyVal` should work on both 2.10 and 2.11, though?