### PR TITLE
Add facility to round up to a duration in TimeLike

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Duration.scala
+++ b/util-core/src/main/scala/com/twitter/util/Duration.scala
@@ -480,5 +480,7 @@ sealed class Duration private[util] (protected val nanos: Long) extends {
    */
   def rem(x: Duration): Duration = this % x
 
-  override def floor(x: Duration): Duration = super.floor(x) // for Java-compatibility
+  // for Java-compatibility
+  override def floor(x: Duration): Duration = super.floor(x)
+  override def ceil(x: Duration): Duration = super.ceil(x)
 }

--- a/util-core/src/main/scala/com/twitter/util/Duration.scala
+++ b/util-core/src/main/scala/com/twitter/util/Duration.scala
@@ -481,6 +481,6 @@ sealed class Duration private[util] (protected val nanos: Long) extends {
   def rem(x: Duration): Duration = this % x
 
   // for Java-compatibility
-  override def floor(x: Duration): Duration = super.floor(x)
-  override def ceil(x: Duration): Duration = super.ceil(x)
+  override def floor(increment: Duration): Duration = super.floor(increment)
+  override def ceil(increment: Duration): Duration = super.ceil(increment)
 }

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -637,6 +637,8 @@ sealed class Time private[util] (protected val nanos: Long) extends {
    *  Finds a diff between this and ''that'' time.
    */
   def minus(that: Time): Duration = this - that
-
-  override def floor(x: Duration): Time = super.floor(x) // for Java-compatibility
+  
+  // for Java-compatibility
+  override def floor(x: Duration): Time = super.floor(x)
+  override def ceil(x: Duration): Time = super.ceil(x) 
 }

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -20,6 +20,8 @@ import java.io.Serializable
 import java.util.concurrent.TimeUnit
 import java.util.{Date, Locale, TimeZone}
 
+import com.twitter.conversions.time.intToTimeableNumber
+
 /**
  * @define now
  *
@@ -201,7 +203,9 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
    * Time object with duration greater than 1.hour can have unexpected
    * results because of timezones.
    */
-  def ceil(increment: Duration): This = floor(increment) + increment
+  // the impl might seem weird but consider the case where this is an exact multiple of the 
+  // increment.
+  def ceil(increment: Duration): This = (this - 1.nanoseconds).floor(increment) + increment
 
   /**
    * Rounds down to the nearest multiple of the given duration.  For example:

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -20,8 +20,6 @@ import java.io.Serializable
 import java.util.concurrent.TimeUnit
 import java.util.{Date, Locale, TimeZone}
 
-import com.twitter.conversions.time.intToTimeableNumber
-
 /**
  * @define now
  *
@@ -203,9 +201,10 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
    * Time object with duration greater than 1.hour can have unexpected
    * results because of timezones.
    */
-  // the impl might seem weird but consider the case where this is an exact multiple of the 
-  // increment.
-  def ceil(increment: Duration): This = (this - 1.nanoseconds).floor(increment) + increment
+  def ceil(increment: Duration): This = {
+    val floored = floor(increment)
+    if (this == floored) floored else floored + increment
+  }
 
   /**
    * Rounds down to the nearest multiple of the given duration.  For example:
@@ -639,6 +638,6 @@ sealed class Time private[util] (protected val nanos: Long) extends {
   def minus(that: Time): Duration = this - that
   
   // for Java-compatibility
-  override def floor(x: Duration): Time = super.floor(x)
-  override def ceil(x: Duration): Time = super.ceil(x) 
+  override def floor(increment: Duration): Time = super.floor(increment)
+  override def ceil(increment: Duration): Time = super.ceil(increment) 
 }

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -195,21 +195,13 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
   /** The difference between the two `TimeLike`s */
   def diff(that: This): Duration
 
-  private[this] def round(f: (Long, Long) => Long, x: Duration): This = (this, x) match {
-    case (Nanoseconds(0), Duration.Nanoseconds(0)) => Undefined
-    case (Nanoseconds(num), Duration.Nanoseconds(0)) => if (num < 0) Bottom else Top
-    case (Nanoseconds(num), Duration.Nanoseconds(denom)) => fromNanoseconds(f(num, denom))
-    case (self, Duration.Nanoseconds(_)) => self
-    case (_, _) => Undefined
-  }
-
   /**
    * Rounds up to the nearest multiple of the given duration.  For example:
    * 127.seconds.ceiling(1.minute) => 3.minutes.  Taking the ceiling of a
    * Time object with duration greater than 1.hour can have unexpected
    * results because of timezones.
    */
-  def ceiling(x: Duration): This = round((num, denom) => ((num + denom - 1)/denom) * denom, x)
+  def ceil(increment: Duration): This = floor(increment) + increment
 
   /**
    * Rounds down to the nearest multiple of the given duration.  For example:
@@ -217,7 +209,13 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
    * Time object with duration greater than 1.hour can have unexpected
    * results because of timezones.
    */
-  def floor(x: Duration): This = round((num, denom) => (num/denom) * denom, x)
+  def floor(increment: Duration): This = (this, increment) match {
+    case (Nanoseconds(0), Duration.Nanoseconds(0)) => Undefined
+    case (Nanoseconds(num), Duration.Nanoseconds(0)) => if (num < 0) Bottom else Top
+    case (Nanoseconds(num), Duration.Nanoseconds(denom)) => fromNanoseconds((num/denom) * denom)
+    case (self, Duration.Nanoseconds(_)) => self
+    case (_, _) => Undefined
+  }
 
   def max(that: This): This =
     if ((this compare that) < 0) that else this

--- a/util-core/src/test/java/com/twitter/util/DurationCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/util/DurationCompilationTest.java
@@ -127,4 +127,12 @@ public class DurationCompilationTest {
 
     Assert.assertEquals(2, b.inSeconds());
   }
+
+  @Test
+  public void testCeil() {
+    Duration a = Duration.fromMilliseconds(3333);
+    Duration b = a.ceil(Duration.fromSeconds(1));
+
+    Assert.assertEquals(4, b.inSeconds());
+  }
 }

--- a/util-core/src/test/java/com/twitter/util/TimeCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/util/TimeCompilationTest.java
@@ -82,6 +82,14 @@ public class TimeCompilationTest {
   }
 
   @Test
+  public void testCeil() {
+    Time a = Time.fromNanoseconds(6666);
+    Time b = a.ceil(Duration.fromMicroseconds(1));
+
+    Assert.assertEquals(7, b.inMicroseconds());
+  }
+
+  @Test
   public void testSince() {
     Time a = Time.now().plus(Duration.fromSeconds(10));
     Time b = Time.epoch().plus(Duration.fromSeconds(10));

--- a/util-core/src/test/scala/com/twitter/util/TimeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimeTest.scala
@@ -288,16 +288,11 @@ trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with GeneratorDrivenProper
     }
   }
 
-  "floor" should {
-    "round down" in {
-      assert(fromSeconds(60).floor(1.minute) === fromSeconds(60))
-      assert(fromSeconds(100).floor(1.minute) === fromSeconds(60))
-      assert(fromSeconds(119).floor(1.minute) === fromSeconds(60))
-      assert(fromSeconds(120).floor(1.minute) === fromSeconds(120))
-    }
-
+  "rounding" should {
+    
     "maintain top and bottom" in {
       assert(Top.floor(1.hour) === Top)
+      assert(Bottom.floor(1.second) === Bottom)
     }
 
     "divide by zero" in {
@@ -307,16 +302,33 @@ trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with GeneratorDrivenProper
     }
 
     "deal with undefineds" in {
-      assert(Bottom.floor(1.second) === Bottom)
       assert(Undefined.floor(0.seconds) === Undefined)
       assert(Undefined.floor(Duration.Top) === Undefined)
       assert(Undefined.floor(Duration.Bottom) === Undefined)
       assert(Undefined.floor(Duration.Undefined) === Undefined)
     }
 
-    "floor itself" in {
+    "round to itself" in {
       for (s <- Seq(Long.MinValue, -1, 1, Long.MaxValue); t = fromNanoseconds(s))
         assert(t.floor(Duration.fromNanoseconds(t.inNanoseconds)) === t)
+    }
+  }
+
+  "floor" should {
+    "round down" in {
+      assert(fromSeconds(60).floor(1.minute) === fromSeconds(60))
+      assert(fromSeconds(100).floor(1.minute) === fromSeconds(60))
+      assert(fromSeconds(119).floor(1.minute) === fromSeconds(60))
+      assert(fromSeconds(120).floor(1.minute) === fromSeconds(120))
+    }
+  }
+
+  "ceiling" should {
+    "round up" in {
+      assert(fromSeconds(60).ceiling(1.minute) === fromSeconds(60))
+      assert(fromSeconds(100).ceiling(1.minute) === fromSeconds(120))
+      assert(fromSeconds(119).ceiling(1.minute) === fromSeconds(120))
+      assert(fromSeconds(120).ceiling(1.minute) === fromSeconds(120))
     }
   }
 

--- a/util-core/src/test/scala/com/twitter/util/TimeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimeTest.scala
@@ -289,46 +289,46 @@ trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with GeneratorDrivenProper
   }
 
   "rounding" should {
-    
+
     "maintain top and bottom" in {
-      assert(Top.floor(1.hour) === Top)
-      assert(Bottom.floor(1.second) === Bottom)
+      assert(Top.floor(1.hour) == Top)
+      assert(Bottom.floor(1.hour) == Bottom)
     }
 
     "divide by zero" in {
-      assert(Zero.floor(Duration.Zero) === Undefined)
-      assert(fromSeconds(1).floor(Duration.Zero) === Top)
-      assert(fromSeconds(-1).floor(Duration.Zero) === Bottom)
+      assert(Zero.floor(Duration.Zero) == Undefined)
+      assert(fromSeconds(1).floor(Duration.Zero) == Top)
+      assert(fromSeconds(-1).floor(Duration.Zero) == Bottom)
     }
 
     "deal with undefineds" in {
-      assert(Undefined.floor(0.seconds) === Undefined)
-      assert(Undefined.floor(Duration.Top) === Undefined)
-      assert(Undefined.floor(Duration.Bottom) === Undefined)
-      assert(Undefined.floor(Duration.Undefined) === Undefined)
+      assert(Undefined.floor(0.seconds) == Undefined)
+      assert(Undefined.floor(Duration.Top) == Undefined)
+      assert(Undefined.floor(Duration.Bottom) == Undefined)
+      assert(Undefined.floor(Duration.Undefined) == Undefined)
     }
 
     "round to itself" in {
-      for (s <- Seq(Long.MinValue, -1, 1, Long.MaxValue); t = fromNanoseconds(s))
-        assert(t.floor(Duration.fromNanoseconds(t.inNanoseconds)) === t)
+      for (s <- Seq(Long.MinValue, -1, 1, Long.MaxValue); t = s.nanoseconds)
+        assert(t.floor(t.inNanoseconds.nanoseconds) == t)
     }
   }
 
   "floor" should {
     "round down" in {
-      assert(fromSeconds(60).floor(1.minute) === fromSeconds(60))
-      assert(fromSeconds(100).floor(1.minute) === fromSeconds(60))
-      assert(fromSeconds(119).floor(1.minute) === fromSeconds(60))
-      assert(fromSeconds(120).floor(1.minute) === fromSeconds(120))
+      assert(60.seconds.floor(1.minute) == 60.seconds)
+      assert(100.seconds.floor(1.minute) == 60.seconds)
+      assert(119.seconds.floor(1.minute) == 60.seconds)
+      assert(120.seconds.floor(1.minute) == 120.seconds)
     }
   }
 
   "ceiling" should {
     "round up" in {
-      assert(fromSeconds(60).ceiling(1.minute) === fromSeconds(60))
-      assert(fromSeconds(100).ceiling(1.minute) === fromSeconds(120))
-      assert(fromSeconds(119).ceiling(1.minute) === fromSeconds(120))
-      assert(fromSeconds(120).ceiling(1.minute) === fromSeconds(120))
+      assert(60.seconds.ceil(1.minute) == 60.seconds)
+      assert(100.seconds.ceil(1.minute) == 120.seconds)
+      assert(119.seconds.ceil(1.minute) == 120.seconds)
+      assert(120.seconds.ceil(1.minute) == 120.seconds)
     }
   }
 


### PR DESCRIPTION
Problem

No rounding operation analgous to floor for rounding up to the closest
multiple of a duration. While less common than floor, ceiling is still
useful.

Solution

Add a ceiling function to TimeLike.