### PR TITLE
Let AsyncStream.scanLeft return values eagerly.

### DIFF
--- a/util-core/src/test/scala/com/twitter/concurrent/exp/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/exp/AsyncStreamTest.scala
@@ -192,6 +192,13 @@ class AsyncStreamTest extends FunSuite with GeneratorDrivenPropertyChecks {
     }
   }
 
+  test("scanLeft is eager") {
+    val never = AsyncStream.fromFuture(Future.never)
+    val hd = never.scanLeft("hi")((_,_) => ???).head
+    assert(hd.isDefined)
+    assert(Await.result(hd) == Some("hi"))
+  }
+
   test("foldLeft") {
     forAll { (a: List[Int]) =>
       def f(s: String, n: Int) = (s.toLong + n).toString


### PR DESCRIPTION
Problem

AsyncStream.scanLeft only provides a value once the next value in the stream
has been satisfied.  Notably, the initial value is not consumable until the
underlying stream has been satisfied.

Solution

Provide values eagerly.

Fixes twitter/util#138