### PR TITLE
Future.sequence

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -354,7 +354,7 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
    *     )
    *   Future.sequence(orderedOperations)
    * 
-   * @param fs a sequence of Function0's that returns Futures to be executed in sequence
+   * @param fs a sequence of Function0s that returns Futures to be executed in sequence
    * @return a `Future[Seq[A]]` containing the results of each future in fs
    */
   def sequence[A](fs: Seq[() => Future[A]]): Future[Seq[A]] = 

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -358,7 +358,7 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
    * @return a `Future[Seq[A]]` containing the results of each future in fs
    */
   def sequence[A](fs: Seq[() => Future[A]]): Future[Seq[A]] = 
-    fs.foldLeft(Future(List.empty[A])) { (resultsFuture, nextFunction) =>
+    fs.foldLeft(Future(Vector.empty[A])) { (resultsFuture, nextFunction) =>
       for {
         results    <- resultsFuture
         nextResult <- nextFunction()

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -339,20 +339,26 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
   def join[A](fs: JList[Future[A]]): Future[Unit] = Futures.join(fs)
 
   /**
-   * Take a sequence and sequentially apply a function f to each item.
-   * Then return all future results as a single Future[Seq[_]].
-   * 
-   * If during execution any f() throws an exception that exception will be returned and 
-   * the remaining futures will not be processed.
-   * 
+   * Take a sequence and sequentially apply a function `f` to each item.
+   * Then return all future results `as` a single Future[Seq[_]].
+   *
+   * If during execution any `f` is satsified `as` a failure ([[Future.exception]])
+   * then that failed Future will be returned and the remaining elements of `as`
+   * will not be processed.
+   *
    * usage:
-   *   Future.traverseSequentially(Seq(1,2,3))(deleteItem)
-   * 
-   * @param as a sequence of A that will have f applied to each item sequentially
-   * @return a `Future[Seq[B]]` containing the results of f being applied to every item in as
+   *  {{{
+   *    // will return a Future of `Seq(2, 3, 4)`
+   *    Future.traverseSequentially(Seq(1, 2, 3)) { i =>
+   *      Future(i + 1)
+   *    }
+   *  }}}
+   *
+   * @param `as` a sequence of `A` that will have `f` applied to each item sequentially
+   * @return a `Future[Seq[B]]` containing the results of `f` being applied to every item in `as`
    */
   def traverseSequentially[A,B](as: Seq[A])(f: A => Future[B]): Future[Seq[B]] =
-    as.foldLeft(Future(Vector.empty[B])) { (resultsFuture, nextItem) =>
+    as.foldLeft(Future.value(Vector.empty[B])) { (resultsFuture, nextItem) =>
       for {
         results    <- resultsFuture
         nextResult <- f(nextItem)

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -340,7 +340,7 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)) map { _ => (%s) }""".format(
 
   /**
    * Take a sequence and sequentally apply a function f to each item.
-   * future sequentially, then return all future results as a single Future[Seq[_]].
+   * Then return all future results as a single Future[Seq[_]].
    * 
    * If during execution any f() throws an exception that exception will be returned and 
    * the remaining futures will not be processed.

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -477,10 +477,10 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
         }
       }
 
-     "traverse" should {
-        class TraverseTestSpy() {     
+     "traverseSequentially" should {
+        class TraverseTestSpy() {
           var goWasCalled = false
-          var promise     = Promise[Int]()    
+          var promise     = Promise[Int]()
           val go          = () => {
             goWasCalled = true
             promise
@@ -494,13 +494,13 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
 
           val results = Future.traverseSequentially(events)(f => f())
 
-          // At this point, none of the promises 
+          // At this point, none of the promises
           // have been fufilled, so only the first function
           // should have been called
           assert(first.goWasCalled)
           assert(!second.goWasCalled)
 
-          // once the first promise completes, the next 
+          // once the first promise completes, the next
           // function in the sequence should be executed
           first.promise.setValue(1)
           assert(second.goWasCalled)

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -477,104 +477,55 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
         }
       }
 
-   "traverse" should {
-      class TraverseTestSpy() {     
-        var goWasCalled = false
-        var promise     = Promise[Int]()    
-        val go          = () => {
-          goWasCalled = true
-          promise
+     "traverse" should {
+        class TraverseTestSpy() {     
+          var goWasCalled = false
+          var promise     = Promise[Int]()    
+          val go          = () => {
+            goWasCalled = true
+            promise
+          }
+        }
+
+        "execute futures in order" in {
+          val first   = new TraverseTestSpy()
+          val second  = new TraverseTestSpy()
+          val events  = Seq(first.go, second.go)
+
+          val results = Future.traverseSequentially(events)(f => f())
+
+          // At this point, none of the promises 
+          // have been fufilled, so only the first function
+          // should have been called
+          assert(first.goWasCalled)
+          assert(!second.goWasCalled)
+
+          // once the first promise completes, the next 
+          // function in the sequence should be executed
+          first.promise.setValue(1)
+          assert(second.goWasCalled)
+
+          // finally, the second promise is fufilled so
+          // we can Await on and check the results
+          second.promise.setValue(2)
+          assert(Await.result(results) == Seq(1, 2))
+        }
+
+        "return with exception when the first future throws" in {
+          val first   = new TraverseTestSpy()
+          val second  = new TraverseTestSpy()
+          val events  = Seq(first.go, second.go)
+          val results = Future.traverseSequentially(events)(f => f())
+
+          first.promise.setException(new Exception)
+
+          intercept[Exception] { Await.result(results) }
+
+          // Since first returned an exception, second should
+          // never have been called
+          assert(!second.goWasCalled)
         }
       }
-
-      "execute futures in order" in {
-        val first   = new TraverseTestSpy()
-        val second  = new TraverseTestSpy()
-        val events  = Seq(first.go, second.go)
-
-        val results = Future.traverseSequentally(events)(f => f())
-
-        // At this point, none of the promises 
-        // have been fufilled, so only the first function
-        // should have been called
-        assert(first.goWasCalled)
-        assert(!second.goWasCalled)
-
-        // once the first promise completes, the next 
-        // function in the sequence should be executed
-        first.promise.setValue(1)
-        assert(second.goWasCalled)
-
-        // finally, the second promise is fufilled so
-        // we can Await on and check the results
-        second.promise.setValue(2)
-        assert(Await.result(results) == Seq(1, 2))
-      }
-
-      "return with exception when the first future throws" in {
-        val first   = new TraverseTestSpy()
-        val second  = new TraverseTestSpy()
-        val events  = Seq(first.go, second.go)
-        val results = Future.traverseSequentally(events)(f => f())
-
-        first.promise.setException(new Exception)
-
-        intercept[Exception] { Await.result(results) }
-
-        // Since first returned an exception, second should
-        // never have been called
-        assert(!second.goWasCalled)
-      }
-    }
-
-   "sequenceEffects" should {
-      class SequenceTestSpy() {     
-        var goWasCalled = false
-        var promise     = Promise[Int]()    
-        val go          = () => {
-          goWasCalled = true
-          promise
-        }
-      }
-
-      "execute futures in order" in {
-        val first   = new SequenceTestSpy()
-        val second  = new SequenceTestSpy()
-        val events  = Seq(first.go, second.go)
-        val results = Future.sequenceEffects(events)
-
-        // At this point, none of the promises 
-        // have been fufilled, so only the first function
-        // should have been called
-        assert(first.goWasCalled)
-        assert(!second.goWasCalled)
-
-        // once the first promise completes, the next 
-        // function in the sequence should be executed
-        first.promise.setValue(1)
-        assert(second.goWasCalled)
-
-        // finally, the second promise is fufilled so
-        // we can Await on and check the results
-        second.promise.setValue(2)
-        assert(Await.result(results) == Seq(1, 2))
-      }
-
-      "return with exception when the first future throws" in {
-        val first   = new SequenceTestSpy()
-        val second  = new SequenceTestSpy()
-        val events  = Seq(first.go, second.go)
-        val results = Future.sequenceEffects(events)
-
-        first.promise.setException(new Exception)
-
-        intercept[Exception] { Await.result(results) }
-
-        // Since first returned an exception, second should
-        // never have been called
-        assert(!second.goWasCalled)
-      }
-    }
 
       "collect" should {
         trait CollectHelper {

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -477,6 +477,55 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
         }
       }
 
+   "sequence" should {
+      class SequenceTestSpy() {     
+        var goWasCalled = false
+        var promise     = Promise[Int]()    
+        val go          = () => {
+          goWasCalled = true
+          promise
+        }
+      }
+
+      "execute futures in order" in {
+        val first   = new SequenceTestSpy()
+        val second  = new SequenceTestSpy()
+        val events  = Seq(first.go, second.go)
+        val results = Future.sequence(events)
+
+        // At this point, none of the promises 
+        // have been fufilled, so only the first function
+        // should have been called
+        assert(first.goWasCalled)
+        assert(!second.goWasCalled)
+
+        // once the first promise completes, the next 
+        // function in the sequence should be executed
+        first.promise.setValue(1)
+        assert(second.goWasCalled)
+
+        // finally, the second promise is fufilled so
+        // we can Await on and check the results
+        second.promise.setValue(2)
+        assert(Await.result(results) == Seq(1, 2))
+      }
+
+      "return with exception when the first future throws" in {
+        val first   = new SequenceTestSpy()
+        val second  = new SequenceTestSpy()
+        val events  = Seq(first.go, second.go)
+        val results = Future.sequence(events)
+
+        first.promise.setException(new Exception)
+
+        intercept[Exception] { Await.result(results) }
+
+        // Since first returned an exception, second should
+        // never have been called
+        assert(!second.goWasCalled)
+      }
+    }
+
       "collect" should {
         trait CollectHelper {
           val p0, p1 = new HandledPromise[Int]


### PR DESCRIPTION
Add a method that allows you to execute an list of futures sequentially

Problem
Most methods that operate on lists of futures do so in parallel, because it's generally inefficient to sequence futures that don't depend on each other.

However there are some use cases for sequencing futures, such as executing side effects that must take place in order. 

Solution

Add a method `sequence` to Future that takes a list of functions that produce futures, and flatMaps them together. We take a list of functions because if you created a list of futures directly, they would already be executing in parallel.

Result

Now you can execute Futures in sequence.
