### PR TITLE
Fix style error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ val pool = new FactoryPool[Int](4) {
 
 It checks the health when you successfully reserve an object (i.e., when the Future yields).
 
-```
 # Hashing
 
 `util-hashing` is a collection of hash functions and hashing distributors (eg. ketama).


### PR DESCRIPTION
Make the Hashing section look like this:

![image](https://cloud.githubusercontent.com/assets/207427/10966362/f4dc4c42-8367-11e5-89d1-aeb8ba4f85f5.png)

Instead of the current: 

![image](https://cloud.githubusercontent.com/assets/207427/10966377/0f03e7ce-8368-11e5-9841-7398a160befb.png)
