### PR TITLE
add the scala-parser-combinators dependency in 2.12 too

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,7 +18,7 @@ object Util extends Build {
 
   val parserCombinators = scalaVersion(sv =>
     CrossVersion.partialVersion(sv) match {
-      case Some((2, 11)) =>
+      case Some((2, 11)) | Some((2, 12)) =>
         Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4")
       case _  => Nil
     }


### PR DESCRIPTION
without this, building twitter-util as part of the Scala 2.12
community build fails