### PR TITLE
Stop takeWhile and dropWhile at predicate match

### DIFF
--- a/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
@@ -205,7 +205,7 @@ sealed abstract class AsyncStream[+A] {
       case FromFuture(fa) => Embed(fa.map { a => if (p(a)) this else empty })
       case Cons(fa, more) => Embed(fa.map { a =>
         if (p(a)) Cons(fa, () => more().takeWhile(p))
-        else more().takeWhile(p)
+        else empty
       })
       case Embed(fas) => Embed(fas.map(_.takeWhile(p)))
     }
@@ -225,7 +225,7 @@ sealed abstract class AsyncStream[+A] {
       case FromFuture(fa) => Embed(fa.map { a => if (p(a)) empty else this })
       case Cons(fa, more) => Embed(fa.map { a =>
         if (p(a)) more().dropWhile(p)
-        else Cons(fa, () => more().dropWhile(p))
+        else Cons(fa, () => more())
       })
       case Embed(fas) => Embed(fas.map(_.dropWhile(p)))
     }

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -322,14 +322,14 @@ class AsyncStreamTest extends FunSuite with GeneratorDrivenPropertyChecks {
   }
 
   test("takeWhile") {
-    forAll { (as: List[Int], p: Int => Boolean) =>
-      assert(toSeq(fromSeq(as).takeWhile(p)) == as.takeWhile(p))
+    forAll(genListAndSentinel) { case (as, x) =>
+      assert(toSeq(fromSeq(as).takeWhile(_ != x)) == as.takeWhile(_ != x))
     }
   }
 
   test("dropWhile") {
-    forAll { (as: List[Int], p: Int => Boolean) =>
-      assert(toSeq(fromSeq(as).dropWhile(p)) == as.dropWhile(p))
+    forAll(genListAndSentinel) { case (as, x) =>
+      assert(toSeq(fromSeq(as).dropWhile(_ != x)) == as.dropWhile(_ != x))
     }
   }
 
@@ -664,6 +664,11 @@ private object AsyncStreamTest {
     as <- Arbitrary.arbitrary[List[Int]]
     n <- Gen.choose(0, as.length)
   } yield (as, n)
+
+  val genListAndSentinel = for {
+    as <- Arbitrary.arbitrary[List[Int]]
+    n <- Gen.choose(0, as.length - 1)
+  } yield (as, as(n))
 
   def await[T](fut: Future[T]) = Await.result(fut, 100.milliseconds)
 


### PR DESCRIPTION
Problem

`takeWhile` and `dropWhile` behave like `filter`. In the former, the
result contains all items matching the condition. In the latter, the
result contains all items *not* matching the condition.

Solution

Modify `takeWhile` to discard everything after the first match. For
`dropWhile`, stop checking the items against the condition after the
first match.

Result

    val seq = Seq(1,2,3,2)

    // Before
    fromSeq(seq).takeWhile(_ != 2)    // Seq(1,3)
    fromSeq(seq).dropWhile(_ != 2)    // Seq(2,2)

    // After
    fromSeq(seq).takeWhile(_ != 2)    // Seq(1)
    fromSeq(seq).dropWhile(_ != 2)    // Seq(2,3,2)
