### PR TITLE
Mark CumulativeGauge System.gc test as flaky

### DIFF
--- a/util-stats/src/test/scala/com/twitter/finagle/stats/CumulativeGaugeTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/CumulativeGaugeTest.scala
@@ -44,6 +44,7 @@ class CumulativeGaugeTest extends FunSuite {
     assert(0 == gauge.numDeregisters.get)
   }
 
+  if (!sys.props.contains("SKIP_FLAKY"))
   test("a CumulativeGauge with size = 1 should deregister after a System.gc when no references are held onto") {
     val gauge = new TestGauge()
     var added = gauge.addGauge { 1.0f }


### PR DESCRIPTION
Problem

On oraclejdk8, a CumulativeGaugeTest fails: https://travis-ci.org/twitter/util/jobs/115956162

Solution

Mark the test as flaky, since it depends on platform-specific/racy behavior (i.e.  it's not really a unit test).