### PR TITLE
Preserve Local settings when logging asynchronously.

### DIFF
--- a/util-logging/src/main/scala/com/twitter/logging/QueueingHandler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/QueueingHandler.scala
@@ -81,6 +81,8 @@ class QueueingHandler(handler: Handler, val maxQueueSize: Int, inferClassNames: 
 
   import QueueingHandler._
 
+  case class RecordWithLocals(record: javalog.LogRecord, locals: Local.Context)
+
   def this(handler: Handler, maxQueueSize: Int) =
     this(handler, maxQueueSize, false)
 
@@ -90,7 +92,7 @@ class QueueingHandler(handler: Handler, val maxQueueSize: Int, inferClassNames: 
   protected val dropLogNode: String = ""
   protected val log: Logger = Logger(dropLogNode)
 
-  private[this] val queue = new AsyncQueue[javalog.LogRecord](maxQueueSize)
+  private[this] val queue = new AsyncQueue[RecordWithLocals](maxQueueSize)
 
   private[this] val closed = new AtomicBoolean(false)
 
@@ -104,13 +106,14 @@ class QueueingHandler(handler: Handler, val maxQueueSize: Int, inferClassNames: 
     DefaultFuturePool {
       // We run this in a FuturePool to avoid satisfying pollers
       // (which flush the record) inline.
-      if (!queue.offer(record))
+      if (!queue.offer(RecordWithLocals(record, Local.save)))
         onOverflow(record)
     }
   }
 
-  private[this] def doPublish(record: javalog.LogRecord): Unit =
-    super.publish(record)
+  private[this] def doPublish(record: RecordWithLocals): Unit = Local.let(record.locals) {
+    super.publish(record.record)
+  }
 
   private[this] def loop(): Future[Unit] = {
     queue.poll().map(doPublish).respond {
@@ -154,3 +157,4 @@ class QueueingHandler(handler: Handler, val maxQueueSize: Int, inferClassNames: 
     Console.err.println(String.format("[%s] log queue overflow - record dropped", Time.now.toString))
   }
 }
+


### PR DESCRIPTION
Problem

When using QueueingHandler, we are losing the context settings set via Local,
such as TraceId, ClientId, etc., because the Local settings aren't transferred to
the formatting/logging task.

Solution

Use Local.let{} around the formatiing task to let it execute in the context of the
thread that was doing the logging.

Result

When using ansyc logging, the log messages instead of something like this:
  I 0320 14:52:53.600 THREAD46: EchoRequest begin
will now incude full context
  I 0320 14:52:26.006 THREAD46: TraceId:d238dc5aeeb46975 EchoRequest begin

(note, there is also inferClassNames parameter to QueueingHandler, that controls
including of class and method names into the logging messages. This stays unchanged).