### PR TITLE
Just changed a typo in Time.scala

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -609,7 +609,7 @@ sealed class Time private[util] (protected val nanos: Long) extends {
   def sinceNow: Duration = since(now)
 
   /**
-   * Duration between current time and the givne time.
+   * Duration between current time and the given time.
    */
   def until(that: Time): Duration = that - this
 


### PR DESCRIPTION
a simple typo in Time.scala that I noticed when going through the code.