### PR TITLE
util-core: toString override for AsyncStream.Cons

### DIFF
--- a/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
@@ -609,6 +609,7 @@ object AsyncStream {
     extends AsyncStream[A] {
     private[this] lazy val _more: AsyncStream[A] = next()
     def more(): AsyncStream[A] = _more
+    override def toString(): String = s"Cons($fa, $next)"
   }
 
   object Cons {


### PR DESCRIPTION
Problem

`Cons` changed from a `case class` to `class` and lost the display of its parameters in `toString`. Visibility of these values is useful for debugging.

Solution

Override `toString` to reinstate the `case class` behavior.

Result

Visible head and tail, e.g.:

    scala> println(0 +:: AsyncStream.empty)
    Cons(ConstFuture(Return(0)), <function0>)