### PR TITLE
2.12-ification

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -47,7 +47,7 @@ object Util extends Build {
     unmanagedClasspath in Compile += Attributed.blank(new java.io.File("doesnotexist")),
     libraryDependencies ++= Seq(
       "junit" % "junit" % "4.8.1" % "test",
-      "org.mockito" % "mockito-all" % "1.9.5" % "test",
+      "org.mockito" % "mockito-all" % "1.10.19" % "test",
       scalatestLib(scalaVersion.value) % "test"
     ),
 
@@ -347,7 +347,7 @@ object Util extends Build {
     name := "util-test",
     libraryDependencies ++= Seq(
       scalatestLib(scalaVersion.value),
-      "org.mockito" % "mockito-all" % "1.9.5"
+      "org.mockito" % "mockito-all" % "1.10.19"
     )
   ).dependsOn(utilCore, utilLogging)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,12 +26,13 @@ object Util extends Build {
     version := libVersion,
     organization := "com.twitter",
     scalaVersion := "2.11.8",
+    crossScalaVersions := Seq("2.11.8", "2.12.0-M4"),
     // Workaround for a scaladoc bug which causes it to choke on empty classpaths.
     unmanagedClasspath in Compile += Attributed.blank(new java.io.File("doesnotexist")),
     libraryDependencies ++= Seq(
       "junit" % "junit" % "4.8.1" % "test",
       "org.mockito" % "mockito-all" % "1.9.5" % "test",
-      "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+      "org.scalatest" %% "scalatest" % "2.2.6" % "test"
     ),
 
     resolvers += "twitter repo" at "https://maven.twttr.com",
@@ -173,7 +174,7 @@ object Util extends Build {
     name := "util-collection",
     libraryDependencies ++= Seq(
       guavaLib,
-      "org.scalacheck"          %% "scalacheck"          % "1.12.2" % "test"
+      "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"
     )
   ).dependsOn(utilCore % "compile->compile;test->test")
 
@@ -186,7 +187,7 @@ object Util extends Build {
     name := "util-core",
     libraryDependencies ++= Seq(
       "com.twitter.common" % "objectsize" % "0.0.10" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.12.2" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.13.1" % "test",
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
     ),
     resourceGenerators in Compile <+=
@@ -254,7 +255,7 @@ object Util extends Build {
     name := "util-hashing",
     libraryDependencies ++= Seq(
       "commons-codec" % "commons-codec" % "1.9" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.12.2" % "test"
+      "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"
     )
   ).dependsOn(utilCore % "test")
 
@@ -302,7 +303,7 @@ object Util extends Build {
       sharedSettings
   ).settings(
     name := "util-stats",
-    libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.12.2" % "test"
+    libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"
   ).dependsOn(utilCore, utilLint)
 
   lazy val utilTest = Project(
@@ -313,7 +314,7 @@ object Util extends Build {
   ).settings(
     name := "util-test",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "2.2.4",
+      "org.scalatest" %% "scalatest" % "2.2.6",
       "org.mockito" % "mockito-all" % "1.9.5"
     )
   ).dependsOn(utilCore, utilLogging)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -218,6 +218,7 @@ object Util extends Build {
     name := "util-core",
     libraryDependencies ++= Seq(
       "com.twitter.common" % "objectsize" % "0.0.10" % "test",
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       scalacheckLib(scalaVersion.value) % "test" exclude ("org.scala-lang.modules", "scala-parser-combinators_2.11"),
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
     ),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,6 +22,22 @@ object Util extends Build {
   val caffeineLib = "com.github.ben-manes.caffeine" % "caffeine" % "2.3.0"
   val jsr305Lib = "com.google.code.findbugs" % "jsr305" % "2.0.1"
 
+  def scalacheckLib(scalaVersion: String) = {
+    val scalacheckVersion = CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 12)) => "1.12.5"
+      case _ => "1.12.2"
+    }
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion
+  }
+
+  def scalatestLib(scalaVersion: String) = {
+    val scalatestVersion = CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 12)) => "2.2.6"
+      case _ => "2.2.4"
+    }
+    "org.scalatest" %% "scalatest" % scalatestVersion
+  }
+
   val sharedSettings = Seq(
     version := libVersion,
     organization := "com.twitter",
@@ -32,7 +48,7 @@ object Util extends Build {
     libraryDependencies ++= Seq(
       "junit" % "junit" % "4.8.1" % "test",
       "org.mockito" % "mockito-all" % "1.9.5" % "test",
-      "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+      scalatestLib(scalaVersion.value) % "test"
     ),
 
     resolvers += "twitter repo" at "https://maven.twttr.com",
@@ -189,7 +205,7 @@ object Util extends Build {
     name := "util-collection",
     libraryDependencies ++= Seq(
       guavaLib,
-      "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"
+      scalacheckLib(scalaVersion.value) % "test"
     )
   ).dependsOn(utilCore % "compile->compile;test->test")
 
@@ -202,7 +218,7 @@ object Util extends Build {
     name := "util-core",
     libraryDependencies ++= Seq(
       "com.twitter.common" % "objectsize" % "0.0.10" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.13.1" % "test",
+      scalacheckLib(scalaVersion.value) % "test" exclude ("org.scala-lang.modules", "scala-parser-combinators_2.11"),
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
     ),
     resourceGenerators in Compile <+=
@@ -270,7 +286,7 @@ object Util extends Build {
     name := "util-hashing",
     libraryDependencies ++= Seq(
       "commons-codec" % "commons-codec" % "1.9" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"
+      scalacheckLib(scalaVersion.value) % "test"
     )
   ).dependsOn(utilCore % "test")
 
@@ -318,7 +334,7 @@ object Util extends Build {
       sharedSettings
   ).settings(
     name := "util-stats",
-    libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"
+    libraryDependencies += scalacheckLib(scalaVersion.value) % "test"
   ).dependsOn(utilCore, utilLint)
 
   lazy val utilTest = Project(
@@ -329,11 +345,10 @@ object Util extends Build {
   ).settings(
     name := "util-test",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "2.2.6",
+      scalatestLib(scalaVersion.value),
       "org.mockito" % "mockito-all" % "1.9.5"
     )
   ).dependsOn(utilCore, utilLogging)
-
 
   lazy val utilThrift = Project(
     id = "util-thrift",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt.Keys._
 import sbt._
 import pl.project13.scala.sbt.JmhPlugin
 import sbtunidoc.Plugin.unidocSettings
-import scoverage.ScoverageSbtPlugin
+import scoverage.ScoverageKeys
 
 object Util extends Build {
   val branch = Process("git" :: "rev-parse" :: "--abbrev-ref" :: "HEAD" :: Nil).!!.trim
@@ -37,7 +37,7 @@ object Util extends Build {
 
     resolvers += "twitter repo" at "https://maven.twttr.com",
 
-    ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := true,
+    ScoverageKeys.coverageHighlighting := true,
 
     scalacOptions := Seq(
       // Note: Add -deprecation when deprecated methods are removed
@@ -96,6 +96,21 @@ object Util extends Build {
         "com.twitter.common.zookeeper" % "client" % zkClientVersion,
         "com.twitter.common.zookeeper" % "group"  % zkGroupVersion
       )
+    },
+
+    libraryDependencies := {
+      libraryDependencies.value.map {
+        case moduleId: ModuleID
+          if moduleId.organization == "org.scoverage"
+          && scalaVersion.value.startsWith("2.12") =>
+          moduleId.copy(name = moduleId.name.replace(scalaVersion.value, "2.11"))
+        case moduleId =>
+          moduleId
+      }
+    },
+
+    ScoverageKeys.coverageEnabled := {
+      !scalaVersion.value.startsWith("2.12")
     }
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.2")

--- a/util-core/src/main/scala/com/twitter/util/Config.scala
+++ b/util-core/src/main/scala/com/twitter/util/Config.scala
@@ -127,16 +127,24 @@ trait Config[T] extends (() => T) {
     val alreadyVisited = mutable.Set[AnyRef]()
     val interestingReturnTypes = Seq(classOf[Required[_]], classOf[Config[_]], classOf[Option[_]])
     val buf = new mutable.ListBuffer[String]
+    val mirror = reflect.runtime.universe.runtimeMirror(getClass.getClassLoader)
     def collect(prefix: String, config: Config[_]) {
       if (!alreadyVisited.contains(config)) {
         alreadyVisited += config
         val nullaryMethods = config.getClass.getMethods.toSeq filter { _.getParameterTypes.isEmpty }
+        val syntheticTermNames: Set[String] = {
+          val configSymbol = mirror.reflect(config).symbol
+          val configMembers = configSymbol.toType.members
+          configMembers.collect {
+            case symbol if symbol.isTerm && symbol.isSynthetic => symbol.name.decodedName.toString
+          }(scala.collection.breakOut)
+        }
         for (method <- nullaryMethods) {
           val name = method.getName
           val rt = method.getReturnType
           if (name != "required" &&
               name != "optional" &&
-              !name.endsWith("$outer") && // no loops!
+              !syntheticTermNames.contains(name) && // no loops, no compiler generated methods!
               interestingReturnTypes.exists(_.isAssignableFrom(rt))) {
             method.invoke(config) match {
               case Unspecified =>

--- a/util-core/src/main/scala/com/twitter/util/Event.scala
+++ b/util-core/src/main/scala/com/twitter/util/Event.scala
@@ -430,20 +430,15 @@ object Witness {
   /**
    * Create a [[Witness]] from a [[Function1]].
    */
-  def apply[T](f: T => Unit): Witness[T] = fromFunction(f)
+  def apply[T](f: T => Unit): Witness[T] = new Witness[T] {
+    def notify(t: T): Unit = f(t)
+  }
 
   /**
    * Create a [[Witness]] from an [[Updatable]].
    */
   def apply[T](u: Updatable[T]): Witness[T] = new Witness[T] {
     def notify(t: T): Unit = u() = t
-  }
-
-  /**
-   * Create a [[Witness]] from a [[Function1]].
-   */
-  def fromFunction[T](f: T => Unit): Witness[T] = new Witness[T] {
-    def notify(t: T): Unit = f(t)
   }
 
   /**
@@ -481,7 +476,7 @@ object Witness {
   /**
    * A [[Witness]] which prints to the console.
    */
-  val printer: Witness[Any] = Witness.fromFunction(println)
+  val printer: Witness[Any] = Witness(println(_: Any))
 }
 
 /**

--- a/util-core/src/main/scala/com/twitter/util/Event.scala
+++ b/util-core/src/main/scala/com/twitter/util/Event.scala
@@ -476,7 +476,7 @@ object Witness {
   /**
    * A [[Witness]] which prints to the console.
    */
-  val printer: Witness[Any] = Witness(println(_))
+  val printer: Witness[Any] = Witness((any: Any) => println(any))
 }
 
 /**

--- a/util-core/src/main/scala/com/twitter/util/Event.scala
+++ b/util-core/src/main/scala/com/twitter/util/Event.scala
@@ -430,15 +430,20 @@ object Witness {
   /**
    * Create a [[Witness]] from a [[Function1]].
    */
-  def apply[T](f: T => Unit): Witness[T] = new Witness[T] {
-    def notify(t: T): Unit = f(t)
-  }
+  def apply[T](f: T => Unit): Witness[T] = fromFunction(f)
 
   /**
    * Create a [[Witness]] from an [[Updatable]].
    */
   def apply[T](u: Updatable[T]): Witness[T] = new Witness[T] {
     def notify(t: T): Unit = u() = t
+  }
+
+  /**
+   * Create a [[Witness]] from a [[Function1]].
+   */
+  def fromFunction[T](f: T => Unit): Witness[T] = new Witness[T] {
+    def notify(t: T): Unit = f(t)
   }
 
   /**
@@ -476,7 +481,7 @@ object Witness {
   /**
    * A [[Witness]] which prints to the console.
    */
-  val printer: Witness[Any] = Witness((any: Any) => println(any))
+  val printer: Witness[Any] = Witness.fromFunction(println)
 }
 
 /**

--- a/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
@@ -112,7 +112,7 @@ class ActivityTest extends FunSuite {
     "cancellation back to the parent future")
   {
     val p = new Promise[Unit]
-    val obs = Activity.future(p).run.changes.register(Witness(_ => ()))
+    val obs = Activity.future(p).run.changes.register(Witness.fromFunction(_ => ()))
     Await.ready(obs.close())
     assert(!p.isDefined)
   }

--- a/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
@@ -112,7 +112,7 @@ class ActivityTest extends FunSuite {
     "cancellation back to the parent future")
   {
     val p = new Promise[Unit]
-    val obs = Activity.future(p).run.changes.register(Witness.fromFunction(_ => ()))
+    val obs = Activity.future(p).run.changes.register(Witness((_: Any) => ()))
     Await.ready(obs.close())
     assert(!p.isDefined)
   }

--- a/util-core/src/test/scala/com/twitter/util/VarTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/VarTest.scala
@@ -36,7 +36,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     assert(Var.sample(s) == "8923")
 
     var buf = mutable.Buffer[String]()
-    s.changes.register(Witness.fromFunction({ v => buf += v }))
+    s.changes.register(Witness({ (v: String) => buf += v; () }))
     assert(buf.toSeq == Seq("8923"))
     v() = 111
     assert(buf.toSeq == Seq("8923", "111"))
@@ -50,8 +50,8 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val v4 = v3 flatMap { i => v0 }
 
     var result = 1
-    v4.changes.register(Witness.fromFunction({ i => result = result+2 })) // result = 3
-    v0.changes.register(Witness.fromFunction({ i => result = result*2 })) // result = 6
+    v4.changes.register(Witness({ (i: Int) => result = result+2 })) // result = 3
+    v0.changes.register(Witness({ (i: Int) => result = result*2 })) // result = 6
     assert(result == 6)
 
     result = 1 // reset the value, but this time the ordering will go v0, v4 because of depth
@@ -65,9 +65,9 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val v1 = Var(2)
     var result = 0
 
-    val o1 = v1.changes.register(Witness.fromFunction({ i => result = result + i })) // result = 2
-    val o2 = v1.changes.register(Witness.fromFunction({ i => result = result * i * i })) // result = 2 * 2 * 2 = 8
-    val o3 = v1.changes.register(Witness.fromFunction({ i => result = result + result + i })) // result = 8 + 8 + 2 = 18
+    val o1 = v1.changes.register(Witness({ (i: Int) => result = result + i })) // result = 2
+    val o2 = v1.changes.register(Witness({ (i: Int) => result = result * i * i })) // result = 2 * 2 * 2 = 8
+    val o3 = v1.changes.register(Witness({ (i: Int) => result = result + result + i })) // result = 8 + 8 + 2 = 18
 
     assert(result == 18) // ensure those three things happened in sequence
 
@@ -101,7 +101,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
 
     // Now maintain a subscription.
     var cur = Var.sample(s)
-    val sub = s.changes.register(Witness.fromFunction({ cur = _ }))
+    val sub = s.changes.register(Witness({ cur = (_: Int) }))
     assert(cur == -1)
 
     assert(us forall (_.observerCount == 1))
@@ -131,7 +131,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
   test("Var(init)") {
     val v = Var(123)
     var cur = Var.sample(v)
-    val sub = v.changes.register(Witness.fromFunction({ cur = _ }))
+    val sub = v.changes.register(Witness({ cur = (_: Int) }))
     v() = 333
     assert(cur == 333)
     v() = 111
@@ -149,8 +149,8 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val b = v map(_*3)
 
     var x, y = 0
-    a.changes.register(Witness.fromFunction({ x = _ }))
-    b.changes.register(Witness.fromFunction({ y = _ }))
+    a.changes.register(Witness({ x = (_: Int) }))
+    b.changes.register(Witness({ y = (_: Int) }))
 
     assert(x == 4)
     assert(y == 6)
@@ -171,13 +171,13 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     }
     val v = Var.async(123) { v =>
       called += 1
-      x.changes.register(Witness.fromFunction({ v() = _ }))
+      x.changes.register(Witness({ v() = (_: Int) }))
       c
     }
 
     assert(called == 0)
     var vv: Int = 0
-    val o = v.changes.register(Witness.fromFunction({ vv = _ }))
+    val o = v.changes.register(Witness({ vv = (_: Int) }))
     assert(called == 1)
     assert(vv == 333)
     assert(closed == Time.Zero)
@@ -186,7 +186,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     assert(vv == 111)
     assert(closed == Time.Zero)
 
-    val o1 = v.changes.register(Witness.fromFunction({ v => () }))
+    val o1 = v.changes.register(Witness({ (v: Int) => () }))
 
     val t = Time.now
     val f = o.close(t)
@@ -275,7 +275,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val contents = List(1,2,3,4)
     val v1 = Var.value(contents)
     assert(Var.sample(v1) eq contents)
-    v1.changes.register(Witness.fromFunction({ l => assert(contents eq l) }))
+    v1.changes.register(Witness({ (l: List[Int]) => assert(contents eq l) }))
   }
 
   /**
@@ -289,8 +289,8 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
       Var.value(i*2)
     }
 
-    val c1 = f.changes.register(Witness.fromFunction({ i => assert(i == 22) }))
-    val c2 = f.changes.register(Witness.fromFunction({ i => assert(i == 22) }))
+    val c1 = f.changes.register(Witness({ (i: Int) => assert(i == 22) }))
+    val c2 = f.changes.register(Witness({ (i: Int) => assert(i == 22) }))
 
     c1.close()
     c2.close()
@@ -299,7 +299,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     v() = 22 // now it's safe to re-observe
 
     var observed = 3
-    f.changes.register(Witness.fromFunction({ i => observed = i }))
+    f.changes.register(Witness({ (i: Int) => observed = i }))
 
     assert(Var.sample(f) == 44)
     assert(Var.sample(v) == 22)
@@ -352,7 +352,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
       val w = newVar(333)
       val x = v flatMap { _ => w }
       var buf = mutable.Buffer[Int]()
-      x.changes.register(Witness.fromFunction({ v => buf += v }))
+      x.changes.register(Witness({ (v: Int) => buf += v; () }))
 
       assert(buf == Seq(333))
       v() = 333
@@ -369,7 +369,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
       }
 
       var buf = mutable.Buffer[Int]()
-      x.changes.register(Witness.fromFunction({ v => buf += v }))
+      x.changes.register(Witness({ (v: Int) => buf += v; () }))
 
       assert(buf == Seq(333))
       v() = 333
@@ -402,7 +402,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val c = a.flatMap(_ => b)
 
     @volatile var j = -1
-    c.changes.register(Witness.fromFunction({ i =>
+    c.changes.register(Witness({ (i: Int) =>
       assert(i == j+1)
       j = i
     }))

--- a/util-core/src/test/scala/com/twitter/util/VarTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/VarTest.scala
@@ -36,7 +36,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     assert(Var.sample(s) == "8923")
 
     var buf = mutable.Buffer[String]()
-    s.changes.register(Witness({ v => buf += v }))
+    s.changes.register(Witness.fromFunction({ v => buf += v }))
     assert(buf.toSeq == Seq("8923"))
     v() = 111
     assert(buf.toSeq == Seq("8923", "111"))
@@ -50,8 +50,8 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val v4 = v3 flatMap { i => v0 }
 
     var result = 1
-    v4.changes.register(Witness({ i => result = result+2 })) // result = 3
-    v0.changes.register(Witness({ i => result = result*2 })) // result = 6
+    v4.changes.register(Witness.fromFunction({ i => result = result+2 })) // result = 3
+    v0.changes.register(Witness.fromFunction({ i => result = result*2 })) // result = 6
     assert(result == 6)
 
     result = 1 // reset the value, but this time the ordering will go v0, v4 because of depth
@@ -65,9 +65,9 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val v1 = Var(2)
     var result = 0
 
-    val o1 = v1.changes.register(Witness({ i => result = result + i })) // result = 2
-    val o2 = v1.changes.register(Witness({ i => result = result * i * i })) // result = 2 * 2 * 2 = 8
-    val o3 = v1.changes.register(Witness({ i => result = result + result + i })) // result = 8 + 8 + 2 = 18
+    val o1 = v1.changes.register(Witness.fromFunction({ i => result = result + i })) // result = 2
+    val o2 = v1.changes.register(Witness.fromFunction({ i => result = result * i * i })) // result = 2 * 2 * 2 = 8
+    val o3 = v1.changes.register(Witness.fromFunction({ i => result = result + result + i })) // result = 8 + 8 + 2 = 18
 
     assert(result == 18) // ensure those three things happened in sequence
 
@@ -101,7 +101,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
 
     // Now maintain a subscription.
     var cur = Var.sample(s)
-    val sub = s.changes.register(Witness({ cur = _ }))
+    val sub = s.changes.register(Witness.fromFunction({ cur = _ }))
     assert(cur == -1)
 
     assert(us forall (_.observerCount == 1))
@@ -131,7 +131,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
   test("Var(init)") {
     val v = Var(123)
     var cur = Var.sample(v)
-    val sub = v.changes.register(Witness({ cur = _ }))
+    val sub = v.changes.register(Witness.fromFunction({ cur = _ }))
     v() = 333
     assert(cur == 333)
     v() = 111
@@ -149,8 +149,8 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val b = v map(_*3)
 
     var x, y = 0
-    a.changes.register(Witness({ x = _ }))
-    b.changes.register(Witness({ y = _ }))
+    a.changes.register(Witness.fromFunction({ x = _ }))
+    b.changes.register(Witness.fromFunction({ y = _ }))
 
     assert(x == 4)
     assert(y == 6)
@@ -171,13 +171,13 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     }
     val v = Var.async(123) { v =>
       called += 1
-      x.changes.register(Witness({ v() = _ }))
+      x.changes.register(Witness.fromFunction({ v() = _ }))
       c
     }
 
     assert(called == 0)
     var vv: Int = 0
-    val o = v.changes.register(Witness({ vv = _ }))
+    val o = v.changes.register(Witness.fromFunction({ vv = _ }))
     assert(called == 1)
     assert(vv == 333)
     assert(closed == Time.Zero)
@@ -186,7 +186,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     assert(vv == 111)
     assert(closed == Time.Zero)
 
-    val o1 = v.changes.register(Witness({ v => () }))
+    val o1 = v.changes.register(Witness.fromFunction({ v => () }))
 
     val t = Time.now
     val f = o.close(t)
@@ -275,7 +275,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val contents = List(1,2,3,4)
     val v1 = Var.value(contents)
     assert(Var.sample(v1) eq contents)
-    v1.changes.register(Witness({ l => assert(contents eq l) }))
+    v1.changes.register(Witness.fromFunction({ l => assert(contents eq l) }))
   }
 
   /**
@@ -289,8 +289,8 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
       Var.value(i*2)
     }
 
-    val c1 = f.changes.register(Witness({ i => assert(i == 22) }))
-    val c2 = f.changes.register(Witness({ i => assert(i == 22) }))
+    val c1 = f.changes.register(Witness.fromFunction({ i => assert(i == 22) }))
+    val c2 = f.changes.register(Witness.fromFunction({ i => assert(i == 22) }))
 
     c1.close()
     c2.close()
@@ -299,7 +299,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     v() = 22 // now it's safe to re-observe
 
     var observed = 3
-    f.changes.register(Witness({ i => observed = i }))
+    f.changes.register(Witness.fromFunction({ i => observed = i }))
 
     assert(Var.sample(f) == 44)
     assert(Var.sample(v) == 22)
@@ -352,7 +352,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
       val w = newVar(333)
       val x = v flatMap { _ => w }
       var buf = mutable.Buffer[Int]()
-      x.changes.register(Witness({ v => buf += v }))
+      x.changes.register(Witness.fromFunction({ v => buf += v }))
 
       assert(buf == Seq(333))
       v() = 333
@@ -369,7 +369,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
       }
 
       var buf = mutable.Buffer[Int]()
-      x.changes.register(Witness({ v => buf += v }))
+      x.changes.register(Witness.fromFunction({ v => buf += v }))
 
       assert(buf == Seq(333))
       v() = 333
@@ -402,7 +402,7 @@ class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
     val c = a.flatMap(_ => b)
 
     @volatile var j = -1
-    c.changes.register(Witness({ i =>
+    c.changes.register(Witness.fromFunction({ i =>
       assert(i == j+1)
       j = i
     }))

--- a/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
@@ -178,12 +178,10 @@ class FormatterTest extends WordSpec {
         } catch {
           case t: Throwable => t
         }
-        assert(Formatter.formatStackTrace(exception, 2).map { scrub(_) } == List(
+        assert(Formatter.formatStackTrace(exception, 1).map { scrub(_) } == List(
           "    at com.twitter.logging.FormatterTest$$.cycle2(FormatterTest.scala:NNN)",
-          "    at com.twitter.logging.FormatterTest$$.apply$mcV$sp(FormatterTest.scala:NNN)",
           "    (...more...)",
           "Caused by java.lang.Exception: Aie!",
-          "    at com.twitter.logging.FormatterTest$$.cycle(FormatterTest.scala:NNN)",
           "    at com.twitter.logging.FormatterTest$$.cycle(FormatterTest.scala:NNN)",
           "    (...more...)"))
 


### PR DESCRIPTION
Cross build for Scala 2.12

Problem

There exists a need to publish artifacts that are binary compatible with Scala 2.12.

Solution
- Modify sbt build defintion to cross build for 2.12.
- Modify main and test sources to compile against 2.12.
- Ensure the use of scoverage artifacts that exist
when targeting 2.12.
- Update scalatest and scalacheck libraries,
when necessary, to versions that support 2.12.

Result
- When targeting 2.12, the scoverage artifacts will
still use their 2.11 versions.
- By default, scoverage is disabled when targeting 2.12.
- Extra type information is added to the main and test
sources, where necessary.
- 2.12 compatible versions of `scalatest` and `scalacheck` are used
when targeting 2.12 only.

<hr/>

Corresponding PR to #162 

Currently, all main and test sources are compiling.

~~Still a work in progress as some tests are failing.~~ All tests passing.