### PR TITLE
Eval: add Serializable to wrapping class

### DIFF
--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -299,7 +299,7 @@ class Eval(target: Option[File]) {
    * NB: If this method is changed, make sure `codeWrapperLineOffset` is correct.
    */
   private[this] def wrapCodeInClass(className: String, code: String) = {
-    "class " + className + " extends (() => Any) {\n" +
+    "class " + className + " extends (() => Any) with java.io.Serializable {\n" +
     "  def apply() = {\n" +
     code + "\n" +
     "  }\n" +


### PR DESCRIPTION
Problem

I'm compiling scala code using eval then executing it, in part remotely with Apache Spark. The problem is that if my code contains a class, that class is compiler into an inner class with a non-Serializable outer class (the wrapping `Evaluator__*` class), and it fails to be sent to the remote workers.

Solution

Simply adding `Serializable` to the outer class allows the inner classes to be serialized (as long as they are also `Serializable` obviously). I can execute my compiled code on my remote workers.

Another option would be to make `wrapCodeInClass` (and `codeWrapperLineOffset`) `protected` instead of `private[this]`, so that I can do it myself.