### PR TITLE
Do not enable scoverage by default

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -113,10 +113,6 @@ object Util extends Build {
         case moduleId =>
           moduleId
       }
-    },
-
-    ScoverageKeys.coverageEnabled := {
-      !scalaVersion.value.startsWith("2.12")
     }
   )
 


### PR DESCRIPTION
Problem

When running tests against a project that depends on artifacts produced by the current util configuration, the following error is thrown:

    java.io.FileNotFoundException: .../util/util-core/target/scala-2.11/scoverage-data/scoverage.measurements.1147 (No such file or directory)

Solution

Do not set coverage to enabled in Build.scala. Rely on users to manually enable
coverage when it is required (as in travis.yml).