### PR TITLE
Add scala.util.Try support

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -104,15 +104,6 @@ object Future {
   def const[A](result: Try[A]): Future[A] = new ConstFuture[A](result)
 
   /**
-   * Creates a satisfied `Future` from a [[scala.util.Try]].
-   *
-   * @see [[value]] for creation from a constant value.
-   * @see [[apply]] for creation from a `Function`.
-   * @see [[exception]] for creation from a `Throwable`.
-   */
-  def const[A](result: scala.util.Try[A]): Future[A] = const(Try.fromScalaTry(result))
-
-  /**
    * Creates a successful satisfied `Future` from the value `a`.
    *
    * @see [[const]] for creation from a [[Try]]

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -104,6 +104,15 @@ object Future {
   def const[A](result: Try[A]): Future[A] = new ConstFuture[A](result)
 
   /**
+   * Creates a satisfied `Future` from a [[scala.util.Try]].
+   *
+   * @see [[value]] for creation from a constant value.
+   * @see [[apply]] for creation from a `Function`.
+   * @see [[exception]] for creation from a `Throwable`.
+   */
+  def const[A](result: scala.util.Try[A]): Future[A] = const(Try.fromScalaTry(result))
+
+  /**
    * Creates a successful satisfied `Future` from the value `a`.
    *
    * @see [[const]] for creation from a [[Try]]

--- a/util-core/src/main/scala/com/twitter/util/Try.scala
+++ b/util-core/src/main/scala/com/twitter/util/Try.scala
@@ -1,6 +1,6 @@
 package com.twitter.util
 
-import scala.util.{ Success, Failure }
+import scala.util.{Success, Failure}
 
 /**
  * The Try type represents a computation that may either result in an exception

--- a/util-core/src/main/scala/com/twitter/util/Try.scala
+++ b/util-core/src/main/scala/com/twitter/util/Try.scala
@@ -17,6 +17,11 @@ object Try {
     }
   }
 
+  /**
+   * Build a Try from a scala.util.Try. This does nothing
+   * more than pattern match and translate Success and Failure
+   * to Return and Throw respectively.
+   */
   def fromScalaTry[R](tr: scala.util.Try[R]): Try[R] =
     tr match {
       case Success(r) => Return(r)

--- a/util-core/src/main/scala/com/twitter/util/Try.scala
+++ b/util-core/src/main/scala/com/twitter/util/Try.scala
@@ -22,7 +22,7 @@ object Try {
    * more than pattern match and translate Success and Failure
    * to Return and Throw respectively.
    */
-  def fromScalaTry[R](tr: scala.util.Try[R]): Try[R] =
+  def fromScala[R](tr: scala.util.Try[R]): Try[R] =
     tr match {
       case Success(r) => Return(r)
       case Failure(e) => Throw(e)
@@ -82,7 +82,7 @@ sealed abstract class Try[+R] {
   /**
    * Convert to a scala.util.Try
    */
-  def asScalaTry: scala.util.Try[R]
+  def asScala: scala.util.Try[R]
 
   /**
    * Returns true if the Try is a Throw, false otherwise.
@@ -226,7 +226,7 @@ object Throw {
 }
 
 final case class Throw[+R](e: Throwable) extends Try[R] {
-  def asScalaTry: scala.util.Try[R] = Failure(e)
+  def asScala: scala.util.Try[R] = Failure(e)
   def isThrow = true
   def isReturn = false
   def throwable: Throwable = e
@@ -266,7 +266,7 @@ object Return {
 }
 
 final case class Return[+R](r: R) extends Try[R] {
-  def asScalaTry: scala.util.Try[R] = Success(r)
+  def asScala: scala.util.Try[R] = Success(r)
   def isThrow: Boolean = false
 
   def isReturn: Boolean = true

--- a/util-core/src/test/scala/com/twitter/util/TryTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TryTest.scala
@@ -199,4 +199,21 @@ class TryTest extends FunSuite {
     val exc = new Exception("boom!")
     assert(Some("OK").orThrow { exc } == Return("OK"))
   }
+
+  test("Try from scala.util.Try works") {
+    import scala.util.{Try => STry}
+
+    assert(Try.fromScalaTry(STry(1)) == Try(1))
+    assert(Try.fromScalaTry(STry(sys.error("boom!"))).isThrow)
+  }
+
+  test("Try to scala.util.Try works") {
+    import scala.util.{Try => STry, Failure, Success}
+
+    assert(STry(1) == Try(1).asScalaTry)
+    assert(Try(sys.error("boom!")).asScalaTry match {
+      case Failure(_) => true
+      case Success(_) => false
+    })
+  }
 }

--- a/util-core/src/test/scala/com/twitter/util/TryTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TryTest.scala
@@ -203,15 +203,15 @@ class TryTest extends FunSuite {
   test("Try from scala.util.Try works") {
     import scala.util.{Try => STry}
 
-    assert(Try.fromScalaTry(STry(1)) == Try(1))
-    assert(Try.fromScalaTry(STry(sys.error("boom!"))).isThrow)
+    assert(Try.fromScala(STry(1)) == Try(1))
+    assert(Try.fromScala(STry(sys.error("boom!"))).isThrow)
   }
 
   test("Try to scala.util.Try works") {
     import scala.util.{Try => STry, Failure, Success}
 
-    assert(STry(1) == Try(1).asScalaTry)
-    assert(Try(sys.error("boom!")).asScalaTry match {
+    assert(STry(1) == Try(1).asScala)
+    assert(Try(sys.error("boom!")).asScala match {
       case Failure(_) => true
       case Success(_) => false
     })


### PR DESCRIPTION
Problem

Scala added a `Try` that is basically isomorphic to Twitter's. Code using Twitter Try and scala.util.Try will almost certainly implement methods to convert between these types.

Solution

Add methods to convert to and from these two Trys. 

Result

This will add a few methods which enable these conversions.
