### PR TITLE
util-eval: Reset reporter between checks

### DIFF
--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -242,6 +242,7 @@ class Eval(target: Option[File]) {
     val id = uniqueId(sourceForString(code))
     val className = "Evaluator__" + id
     val wrappedCode = wrapCodeInClass(className, code)
+    resetReporter()
     compile(wrappedCode) // may throw CompilerException
   }
 
@@ -265,6 +266,11 @@ class Eval(target: Option[File]) {
   def findClass(className: String): Class[_] = {
     compiler.findClass(className).getOrElse { throw new ClassNotFoundException("no such class: " + className) }
   }
+
+  private[util] def resetReporter() = {
+    compiler.resetReporter()
+  }
+
 
   private[util] def uniqueId(code: String, idOpt: Option[Int] = Some(jvmId)): String = {
     val digest = MessageDigest.getInstance("SHA-1").digest(code.getBytes())
@@ -531,6 +537,12 @@ class Eval(target: Option[File]) {
       cache.clear()
       reporter.reset()
       classLoader = new AbstractFileClassLoader(target, this.getClass.getClassLoader)
+    }
+
+    def resetReporter() {
+      synchronized {
+        reporter.reset()
+      }
     }
 
     object Debug {

--- a/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
+++ b/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
@@ -205,7 +205,7 @@ class EvalTest extends WordSpec {
         assert(eval.errors.nonEmpty)
       }
 
-      "reset reporter between invocations" in {
+      "reset state between invocations" in {
         val ctx = new Ctx
         import ctx._
 
@@ -214,6 +214,22 @@ class EvalTest extends WordSpec {
         }
         assert(eval.errors.nonEmpty)
         assert(eval[Int]("val d = 3; val e = 2; d + e", true) == 5)
+        assert(eval.errors.isEmpty)
+      }
+
+      "reporter should be reset between checks, but loaded class should remain" in {
+        val ctx = new Ctx
+        import ctx._
+
+        // compile and load compiled class
+        eval.compile("class A()")
+
+        intercept[Throwable] {
+          eval.check("new B()")
+        }
+        assert(eval.errors.nonEmpty)
+
+        eval.check("new A()")
         assert(eval.errors.isEmpty)
       }
     }


### PR DESCRIPTION
Problem

When you want to use the util-eval for validating the correctness of a small chunk of code, you have to reset whole state between invocations (flag resetState=true), which is expensive when you already have a bunch of compiled an loaded classes. Without this, if one check fails, all subsequent checks will fail as well, since some errors has been reported previously.

Solution

Scala compiler API allows for resetting just the reporter, so that compiled and loaded classes can remain for re-usage for next checks.

Result

Public API remains the same, however the internal API has one new synchronized method `resetReporter()` which does what is explained in the "Solution" section.