### PR TITLE
reset reporter while apply compiling

### DIFF
--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -580,6 +580,9 @@ class Eval(target: Option[File]) {
       if (Debug.enabled)
         Debug.printWithLineNumbers(code)
 
+      //reset reporter, or will always throw exception after one error while resetState==false
+      resetReporter()
+
       // if you're looking for the performance hit, it's 1/2 this line...
       val compiler = new global.Run
       val sourceFiles = List(new BatchSourceFile("(inline)", code))

--- a/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
+++ b/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
@@ -217,6 +217,18 @@ class EvalTest extends WordSpec {
         assert(eval.errors.isEmpty)
       }
 
+      "reset reporter between inPlace invocations" in {
+        val ctx = new Ctx
+        import ctx._
+
+        intercept[Throwable] {
+          eval.inPlace[Int]("val a = 3; val b = q; a + b")
+        }
+        assert(eval.errors.nonEmpty)
+        assert(eval.inPlace[Int]("val d = 3; val e = 2; d + e") == 5)
+        assert(eval.errors.isEmpty)
+      }
+
       "reporter should be reset between checks, but loaded class should remain" in {
         val ctx = new Ctx
         import ctx._


### PR DESCRIPTION
Problem

I notice that the former release 6.36.0 reset the reporter after check(), which is not enough. I my use case, I would like to use apply with resetState=false (or simply inPlace), without check it before ( check method requires compiling every time, but apply method has cache).
Under such circumstance, if I offer a pice of code with syntax error, it will throw CompilerException every time even if I correct it. It’s because the reporter hasn’t been reset. 

Solution

Simply add resetReporter before compile will solve the problem.

Result

It is self-explanatory based on the solution.
