### PR TITLE
util-logging: Pick up log file size

### DIFF
--- a/util-logging/src/main/scala/com/twitter/logging/FileHandler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/FileHandler.scala
@@ -166,8 +166,10 @@ class FileHandler(
   }
 
   private def openStream(): OutputStream = {
-    val dir = new File(filename).getParentFile
+    val file = new File(filename)
+    val dir = file.getParentFile
     if ((dir ne null) && !dir.exists) dir.mkdirs
+    bytesWrittenToFile = if (file.exists()) file.length() else 0
     new FileOutputStream(filename, append)
   }
 
@@ -176,7 +178,6 @@ class FileHandler(
       stream = openStream()
       openTime = Time.now.inMilliseconds
       nextRollTime = computeNextRollTime(openTime)
-      bytesWrittenToFile = 0
     }
   }
 

--- a/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
@@ -338,7 +338,7 @@ class FileHandlerTest extends WordSpec with TempFolder {
           }
           val files = listLogFiles(folderName+"/LogFileDir")
           files.foreach { f: File =>
-            val len = f.length().megabytes
+            val len = f.length().bytes
             if (len > fileSizeInMegaBytes.megabytes) {
               fail("Failed to roll over the log file")
             }

--- a/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
@@ -330,7 +330,6 @@ class FileHandlerTest extends WordSpec with TempFolder {
         }
         handler2.close()
 
-
         def listLogFiles(dir: String):List[File] = {
           val d = new File(dir)
           if (d.exists && d.isDirectory) {
@@ -349,6 +348,5 @@ class FileHandlerTest extends WordSpec with TempFolder {
         }
       }
     }
-
   }
 }

--- a/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
@@ -311,7 +311,7 @@ class FileHandlerTest extends WordSpec with TempFolder {
       * The test succeeds if the roll over takes place as desired else fails.
       */
     withTempFolder {
-      1 to 5 foreach{testRun =>
+      (1 to 5) foreach { testRun =>
         s" should succeed to rollover at set limit when test is restarted, execution ${testRun}" in {
           val logLevel = Level.INFO
           val fileSizeInMegaBytes: Long = 1
@@ -324,7 +324,7 @@ class FileHandlerTest extends WordSpec with TempFolder {
             formatter = BareFormatter
           ).apply()
 
-          for (a <- 1 to 10000){
+          for (a <- 1 to 10000) {
             handler.publish(record1)
           }
 
@@ -337,9 +337,9 @@ class FileHandlerTest extends WordSpec with TempFolder {
             }
           }
           val files = listLogFiles(folderName+"/LogFileDir")
-          files.foreach{f: File =>
+          files.foreach { f: File =>
             val len = f.length().bytes
-            if (len > fileSizeInMegaBytes.megabytes){
+            if (len > fileSizeInMegaBytes.megabytes) {
               fail("Failed to roll over the log file")
             }
           }

--- a/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
@@ -22,10 +22,9 @@ import java.util.{Calendar, Date, logging => javalog}
 import org.junit.runner.RunWith
 import org.scalatest.WordSpec
 import org.scalatest.junit.JUnitRunner
-
 import com.twitter.conversions.storage._
 import com.twitter.conversions.time._
-import com.twitter.util.{TempFolder, Time}
+import com.twitter.util.{StorageUnit, TempFolder, Time}
 
 
 @RunWith(classOf[JUnitRunner])
@@ -304,47 +303,52 @@ class FileHandlerTest extends WordSpec with TempFolder {
     }
 
     /**
-      * Execute this test individually to affirm that the roll policy based upon the size works
-      * even after the test case is executed couple of times.
       * This test mimics the scenario that, if log file exists, FileHandler should pick up it's size
       * and roll over at the set limit, in order to prevent the file size from growing.
       * The test succeeds if the roll over takes place as desired else fails.
       */
     withTempFolder {
-      (1 to 5).foreach { testRun =>
-        s" should succeed to rollover at set limit when test is restarted, execution ${testRun}" in {
-          val logLevel = Level.INFO
-          val fileSizeInMegaBytes: Long = 1
-          val record1 = new javalog.LogRecord(logLevel, "Sending bytes to fill up file")
-          val handler = FileHandler(
-            filename = folderName+"/LogFileDir/testFileSize.log",
-            rollPolicy = Policy.MaxSize(fileSizeInMegaBytes.megabytes),
-            rotateCount = 8,
-            append = true,
-            formatter = BareFormatter
-          ).apply()
+      "rollover at set limit when test is restarted, execution" in {
+        val logLevel = Level.INFO
+        val fileSizeInMegaBytes: Long = 1
+        val record1 = new javalog.LogRecord(logLevel, "Sending bytes to fill up file")
+        val filename = folderName + "/LogFileDir/testFileSize.log"
+        val rollPolicy = Policy.MaxSize(fileSizeInMegaBytes.megabytes)
+        val rotateCount = 8
+        val append = true
+        val formatter = BareFormatter
 
-          for (a <- 1 to 10000) {
-            handler.publish(record1)
-          }
+        val handler = FileHandler(filename, rollPolicy, append, rotateCount, formatter).apply()
+        for (a <- 1 to 20000) {
+          handler.publish(record1)
+        }
+        handler.close()
 
-          def listLogFiles(dir: String):List[File] = {
-            val d = new File(dir)
-            if (d.exists && d.isDirectory) {
-              d.listFiles.filter(_.isFile).toList
-            } else {
-              List[File]()
-            }
+        val handler2 = FileHandler(filename,rollPolicy, append, rotateCount, formatter).apply()
+        for (a <- 1 to 20000) {
+          handler2.publish(record1)
+        }
+        handler2.close()
+
+
+        def listLogFiles(dir: String):List[File] = {
+          val d = new File(dir)
+          if (d.exists && d.isDirectory) {
+            d.listFiles.filter(_.isFile).toList
+          } else {
+            List[File]()
           }
-          val files = listLogFiles(folderName+"/LogFileDir")
-          files.foreach { f: File =>
-            val len = f.length().bytes
-            if (len > fileSizeInMegaBytes.megabytes) {
-              fail("Failed to roll over the log file")
-            }
+        }
+
+        val files = listLogFiles(folderName + "/LogFileDir")
+        files.foreach { f: File =>
+          val len = f.length().bytes
+          if (len > fileSizeInMegaBytes.megabytes) {
+            fail("Failed to roll over the log file")
           }
         }
       }
     }
+
   }
 }

--- a/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
@@ -311,7 +311,7 @@ class FileHandlerTest extends WordSpec with TempFolder {
       * The test succeeds if the roll over takes place as desired else fails.
       */
     withTempFolder {
-      (1 to 5) foreach { testRun =>
+      (1 to 5).foreach { testRun =>
         s" should succeed to rollover at set limit when test is restarted, execution ${testRun}" in {
           val logLevel = Level.INFO
           val fileSizeInMegaBytes: Long = 1
@@ -338,7 +338,7 @@ class FileHandlerTest extends WordSpec with TempFolder {
           }
           val files = listLogFiles(folderName+"/LogFileDir")
           files.foreach { f: File =>
-            val len = f.length().bytes
+            val len = f.length().megabytes
             if (len > fileSizeInMegaBytes.megabytes) {
               fail("Failed to roll over the log file")
             }


### PR DESCRIPTION
Problem

FileHandler sets 'bytesWrittenToFile' as 0 in 'openLog()'.
This forces log file size to 0 every-time application is restarted, even if it exists.

Solution

Set 'bytesWrittenToFile' as file size in openStream(), if log file exists.
Else set it to 0. Remove 'bytesWrittenToFile' from 'openLog()'

Result

As a result of this merge, the FileHandler will rotate log files with log policy based on Max file size when the limit is reached and prevent the files from growing too large.

ISSUE: #176