### PR TITLE
Make asyncFlag and asyncMaxSizeFlag protected fields so they can acce…

### DIFF
--- a/util-logging/src/main/scala/com/twitter/logging/App.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/App.scala
@@ -38,9 +38,9 @@ trait Logging { self: App =>
   protected[this] val outputFlag = flag("log.output", defaultOutput, "Output file")
   protected[this] val levelFlag = flag("log.level", defaultLogLevel, "Log level")
 
-  private[this] val asyncFlag = flag("log.async", true, "Log asynchronously")
+  protected[this] val asyncFlag = flag("log.async", true, "Log asynchronously")
 
-  private[this] val asyncMaxSizeFlag =
+  protected[this] val asyncMaxSizeFlag =
     flag("log.async.maxsize", 4096, "Max queue size for async logging")
 
   // FileHandler-related flags are ignored if outputFlag is not overridden.


### PR DESCRIPTION
Problem:
With the fields being marked as private it was not possible to properly override the "handlers" method as you could not
initialize the QueuingHandler.
https://github.com/twitter/twitter-server/issues/46

Solution:
Set the flags to protected like the other flags.