### PR TITLE
Allow overriding classloader used by eval. Necessary for classloader hierachies.

### DIFF
--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -460,6 +460,12 @@ class Eval(target: Option[File]) {
     classpath.value = (pathList ::: impliedClassPath).mkString(File.pathSeparator)
   }
 
+  /** Class loader for finding classes compiled by StringCompiler.
+  *  Override if the classloader of Eval does not have access to
+  *  all classes used by the code it compiles.
+  */
+  def classLoader = this.getClass.getClassLoader
+
   /**
    * Dynamic scala compiler. Lots of (slow) state is created, so it may be advantageous to keep
    * around one of these and reuse it.
@@ -518,7 +524,7 @@ class Eval(target: Option[File]) {
      * Class loader for finding classes compiled by this StringCompiler.
      * After each reset, this class loader will not be able to find old compiled classes.
      */
-    var classLoader = new AbstractFileClassLoader(target, this.getClass.getClassLoader)
+    var classLoader = new AbstractFileClassLoader(target, Eval.this.classLoader)
 
     def reset() {
       targetDir match {
@@ -535,7 +541,7 @@ class Eval(target: Option[File]) {
       }
       cache.clear()
       reporter.reset()
-      classLoader = new AbstractFileClassLoader(target, this.getClass.getClassLoader)
+      classLoader = new AbstractFileClassLoader(target, Eval.this.classLoader)
     }
 
     def resetReporter(): Unit = {

--- a/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
+++ b/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
@@ -248,7 +248,7 @@ class EvalTest extends WordSpec {
 
     "eval with overriden classloader" in {
       val eval = new Eval{
-        override def classLoader = this.getClass.getClassLoder
+        override def classLoader = this.getClass.getClassLoader
       }
       assert(eval.apply[Int]("1 + 1") == 2)
     }

--- a/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
+++ b/util-eval/src/test/scala/com/twitter/util/EvalTest.scala
@@ -245,5 +245,12 @@ class EvalTest extends WordSpec {
         assert(eval.errors.isEmpty)
       }
     }
+
+    "eval with overriden classloader" in {
+      val eval = new Eval{
+        override def classLoader = this.getClass.getClassLoder
+      }
+      assert(eval.apply[Int]("1 + 1") == 2)
+    }
   }
 }


### PR DESCRIPTION
Problem

When trying to use Eval in a runtime environment where libraries are isolated in their own classloaders (Scala cbt, assumingly OSGI), Eval.getClass.getClassloader cannot load classes outside of the twitter libraries. The code that is trying to be evaluated may however rely on such classes which currently leads to a ClassNotFound exception.

Solution

I added an override hook for which classloader to use, which the runtime environment can use to inject the correct classloader.

Result

No effects on existing consumers, as they do not override this new member.
