### PR TITLE
removing deprecated QueueProxy in util-core FactoryPool/SimplePool

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,10 @@ Next Version
 
 6.25.0  2015-06-22
 
+API Changes:
+  * util-core: `FactoryPool`/`SimplePool` now inherits
+  `scala.collection.mutable.Queue[A]` not deprecated `scala.collection.mutable.QueueProxy[A]`
+
 Changes in Runtime Behavior:
   * util-events: Enable event sink by default.
 
@@ -169,7 +173,7 @@ Documentation:
 
 6.21.2  2014-09-08
   * util-cache: Adds a Guava-backed asynchronous cache
-  * util-core: Fixed FuturePool for NLRC
+  * util-core: Fixed FuturePool for NLRCK
   * util-core: Improve java friendliness of futures
   * util-core: Make register/close on Event() work atomically
   * util-core: Reimplement Buf.Utf8 encoder/extractor using io.Charsets

--- a/util-core/src/test/scala/com/twitter/util/PoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PoolTest.scala
@@ -52,7 +52,7 @@ class PoolTest extends WordSpec {
         assert(Await.result(promise) === 8)
         assert(Await.result(pool.reserve()) === 6)
         intercept[TimeoutException] {
-          Await.result(pool.reserve, 1.millisecond)
+          Await.result(pool.reserve(), 1.millisecond)
         }
       }
 


### PR DESCRIPTION
### Problem

Found a compiler warning, `mutable.QueueProxy` in `Factory/SimplePool` implementation; specifically a helper class `HealthyQueue`.

```
[warn] /git/util/util-core/src/main/scala/com/twitter/util/Pool.scala:60: trait QueueProxy in package mutable is deprecated: Proxying is deprecated due to lack of use and compiler-level support.
[warn]   extends mutable.QueueProxy[Future[A]]
[warn]                   ^
``` 

### Solution

Being that we are using mutable collections, we can modify HealthyQueue to extend `mutable.Queue[Future[A]]` instead of `mutable.QueueProxy[Future[A]]`


### Result
The underlying impl. was always `mutable.Queue[Future[A]]`, so there should be no interface/functionality change. 

