### PR TITLE
Modify closeOnExit to call close after app exit

### DIFF
--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -104,7 +104,6 @@ trait App extends Closable with CloseAwaitably {
 
   /**
    * This is satisfied when all members of `exits` and `lastExits` have closed.
-   * Note
    *
    * @note Access needs to be mediated via the intrinsic lock.
    */

--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -138,7 +138,7 @@ trait App extends Closable with CloseAwaitably {
     } else {
       // `close()` already called, we need to close this here, but only
       // after `close()` completes and `closing` is satisfied
-      closing.transform {_ => closable.close(closeDeadline) }
+      closing.transform { _ => closable.close(closeDeadline) }
     }
   }
 

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -128,4 +128,37 @@ class AppTest extends FunSuite {
       assert(f.isDefined)
     }
   }
+
+  test("App: closes all closables that were added by closeOnExit") {
+    val app = new TestApp(() => ())
+
+    @volatile var closed = false
+    val closable = Closable.make { _ =>
+      closed = true
+      Future.Done
+    }
+
+    app.closeOnExit(closable)
+
+    assert(!closed)
+    app.main(Array.empty)
+    assert(closed)
+  }
+
+  test("App: closes all closables that were added by closeOnExit after app exited") {
+    val app = new TestApp(() => ())
+
+    @volatile var closed = false
+    val closable = Closable.make { _ =>
+      closed = true
+      Future.Done
+    }
+
+    assert(!closed)
+    app.main(Array.empty)
+    assert(!closed)
+
+    app.closeOnExit(closable)
+    assert(closed)
+  }
 }

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -111,7 +111,7 @@ class AppTest extends FunSuite {
     Time.withCurrentTimeFrozen { ctl =>
       var n1, n2 = 0
       val c1 = Closable.make { _ => n1 += 1; Future.never }
-      val c2 = Closable.make { _ => n2 += 1; Future.Done }
+      val c2 = Closable.make { _ => n2 += 1; Future.never }
       a.closeOnExitLast(c2)
       a.closeOnExit(c1)
       val f = a.close(Time.now + 1.second)
@@ -150,7 +150,6 @@ class AppTest extends FunSuite {
       assert(n2 == 0)
       assert(n3 == 0)
       assert(n4 == 0)
-
       assert(!f.isDefined)
 
       a.closeOnExitLast(c4)
@@ -160,6 +159,7 @@ class AppTest extends FunSuite {
       assert(n2 == 0)
       assert(n3 == 1)
       assert(n4 == 0)
+      assert(!f.isDefined)
 
       ctl.advance(2.seconds)
       t.tick()
@@ -168,7 +168,49 @@ class AppTest extends FunSuite {
       assert(n2 == 1)
       assert(n3 == 1)
       assert(n4 == 1)
+      assert(f.isDefined)
+    }
+  }
 
+  test("App: late closeOnExitLast closes stalled second phase") {
+    val t = new MockTimer
+    val a = new App {
+      override lazy val shutdownTimer = t
+      def main() = ()
+    }
+
+    Time.withCurrentTimeFrozen { ctl =>
+      var n1, n2, n3, n4 = 0
+      val c1 = Closable.make { _ => n1 += 1; Future.never } // Exit
+      val c2 = Closable.make { _ => n2 += 1; Future.never } // ExitLast
+      val c3 = Closable.make { _ => n3 += 1; Future.never } // Late Exit
+      val c4 = Closable.make { _ => n4 += 1; Future.never } // Late ExitLast
+      a.closeOnExitLast(c2)
+      a.closeOnExit(c1)
+      val f = a.close(Time.now + 1.second)
+
+      assert(n1 == 1)
+      assert(n2 == 0)
+      assert(n3 == 0)
+      assert(n4 == 0)
+      assert(!f.isDefined)
+
+      a.closeOnExitLast(c4)
+      a.closeOnExit(c3)
+
+      assert(n1 == 1)
+      assert(n2 == 0)
+      assert(n3 == 1)
+      assert(n4 == 0)
+      assert(!f.isDefined)
+
+      ctl.advance(2.seconds)
+      t.tick()
+
+      assert(n1 == 1)
+      assert(n2 == 1)
+      assert(n3 == 1)
+      assert(n4 == 1)
       assert(f.isDefined)
     }
   }


### PR DESCRIPTION
Problem

We've run into a race condition where our app is shutdown prior to
closeOnExit getting called. The Closables that were added via
closeOnExit subsequent to app shutdown are never closed.

Solution

Modify closeOnExit to check if shutdown has already been called. If it
is, close the Closable inline.

Result

The caller need not be concerned with causing a race condition between
app.close() and app.closeOnExit().
