### PR TITLE
Enable ByteReader  to read unsigned longs

### DIFF
--- a/util-core/src/main/scala/com/twitter/io/ByteReader.scala
+++ b/util-core/src/main/scala/com/twitter/io/ByteReader.scala
@@ -401,25 +401,35 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
   private val unsignedLongMaxValue: BigInt = BigInt("18446744073709551615")
 
   def readUnsignedLongBE(): BigInt = {
-    val arr = Array.ofDim[Byte](8)
+    checkRemaining(8)
+    val ret =
+      BigInt(buf.get(pos    ) & 0xff) << 56 |
+      BigInt(buf.get(pos + 1) & 0xff) << 48 |
+      BigInt(buf.get(pos + 2) & 0xff) << 40 |
+      BigInt(buf.get(pos + 3) & 0xff) << 32 |
+      BigInt(buf.get(pos + 4) & 0xff) << 24 |
+      BigInt(buf.get(pos + 5) & 0xff) << 16 |
+      BigInt(buf.get(pos + 6) & 0xff) <<  8 |
+      BigInt(buf.get(pos + 7) & 0xff)
+    pos += 8
 
-    for (i <- 0 until 8) {
-      val b = readByte()
-      arr(i) = b
-    }
-
-    BigInt(arr) & unsignedLongMaxValue
+    ret & unsignedLongMaxValue
   }
 
   def readUnsignedLongLE(): BigInt = {
-    val arr = Array.ofDim[Byte](8)
+    checkRemaining(8)
+    val ret =
+      BigInt(buf.get(pos    ) & 0xff)       |
+      BigInt(buf.get(pos + 1) & 0xff) <<  8 |
+      BigInt(buf.get(pos + 2) & 0xff) << 16 |
+      BigInt(buf.get(pos + 3) & 0xff) << 24 |
+      BigInt(buf.get(pos + 4) & 0xff) << 32 |
+      BigInt(buf.get(pos + 5) & 0xff) << 40 |
+      BigInt(buf.get(pos + 6) & 0xff) << 48 |
+      BigInt(buf.get(pos + 7) & 0xff) << 56
+    pos += 8
 
-    for (i <- 0 until 8) {
-      val b = readByte()
-      arr(7 - i) = b
-    }
-
-    BigInt(arr) & unsignedLongMaxValue
+    ret & unsignedLongMaxValue
   }
 
 

--- a/util-core/src/main/scala/com/twitter/io/ByteReader.scala
+++ b/util-core/src/main/scala/com/twitter/io/ByteReader.scala
@@ -401,14 +401,14 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
   def readUnsignedLongBE(): BigInt = {
     checkRemaining(8)
     val ret =
-        (buf.get(pos + 7) & 0xff).toLong        |
-        (buf.get(pos + 6) & 0xff).toLong <<  8  |
-        (buf.get(pos + 5) & 0xff).toLong << 16  |
-        (buf.get(pos + 4) & 0xff).toLong << 24  |
-        (buf.get(pos + 3) & 0xff).toLong << 32  |
-        (buf.get(pos + 2) & 0xff).toLong << 40  |
-        (buf.get(pos + 1) & 0xff).toLong << 48  |
-        BigInt((buf.get(pos) & 0xff).toLong) << 56
+      (buf.get(pos + 7) & 0xff).toLong        |
+      (buf.get(pos + 6) & 0xff).toLong <<  8  |
+      (buf.get(pos + 5) & 0xff).toLong << 16  |
+      (buf.get(pos + 4) & 0xff).toLong << 24  |
+      (buf.get(pos + 3) & 0xff).toLong << 32  |
+      (buf.get(pos + 2) & 0xff).toLong << 40  |
+      (buf.get(pos + 1) & 0xff).toLong << 48  |
+      BigInt((buf.get(pos) & 0xff).toLong) << 56
     pos += 8
 
     ret
@@ -417,14 +417,14 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
   def readUnsignedLongLE(): BigInt = {
     checkRemaining(8)
     val ret =
-            (buf.get(pos    ) & 0xff).toLong       |
-            (buf.get(pos + 1) & 0xff).toLong <<  8 |
-            (buf.get(pos + 2) & 0xff).toLong << 16 |
-            (buf.get(pos + 3) & 0xff).toLong << 24 |
-            (buf.get(pos + 4) & 0xff).toLong << 32 |
-            (buf.get(pos + 5) & 0xff).toLong << 40 |
-            (buf.get(pos + 6) & 0xff).toLong << 48 |
-            BigInt(buf.get(pos + 7) & 0xff) << 56
+      (buf.get(pos    ) & 0xff).toLong       |
+      (buf.get(pos + 1) & 0xff).toLong <<  8 |
+      (buf.get(pos + 2) & 0xff).toLong << 16 |
+      (buf.get(pos + 3) & 0xff).toLong << 24 |
+      (buf.get(pos + 4) & 0xff).toLong << 32 |
+      (buf.get(pos + 5) & 0xff).toLong << 40 |
+      (buf.get(pos + 6) & 0xff).toLong << 48 |
+      BigInt(buf.get(pos + 7) & 0xff) << 56
     pos += 8
 
     ret

--- a/util-core/src/main/scala/com/twitter/io/ByteReader.scala
+++ b/util-core/src/main/scala/com/twitter/io/ByteReader.scala
@@ -398,8 +398,6 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
     ret
   }
 
-  private val unsignedLongMaxValue: BigInt = BigInt("18446744073709551615")
-
   def readUnsignedLongBE(): BigInt = {
     checkRemaining(8)
     val ret =
@@ -413,7 +411,7 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
         BigInt((buf.get(pos) & 0xff).toLong) << 56
     pos += 8
 
-    ret & unsignedLongMaxValue
+    ret
   }
 
   def readUnsignedLongLE(): BigInt = {
@@ -429,7 +427,7 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
             BigInt(buf.get(pos + 7) & 0xff) << 56
     pos += 8
 
-    ret & unsignedLongMaxValue
+    ret
   }
 
 

--- a/util-core/src/main/scala/com/twitter/io/ByteReader.scala
+++ b/util-core/src/main/scala/com/twitter/io/ByteReader.scala
@@ -403,14 +403,14 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
   def readUnsignedLongBE(): BigInt = {
     checkRemaining(8)
     val ret =
-      BigInt(buf.get(pos    ) & 0xff) << 56 |
-            (buf.get(pos + 1) & 0xff).toLong << 48 |
-            (buf.get(pos + 2) & 0xff).toLong << 40 |
-            (buf.get(pos + 3) & 0xff).toLong << 32 |
-            (buf.get(pos + 4) & 0xff).toLong << 24 |
-            (buf.get(pos + 5) & 0xff).toLong << 16 |
-            (buf.get(pos + 6) & 0xff).toLong <<  8 |
-            (buf.get(pos + 7) & 0xff).toLong
+        (buf.get(pos + 7) & 0xff).toLong        |
+        (buf.get(pos + 6) & 0xff).toLong <<  8  |
+        (buf.get(pos + 5) & 0xff).toLong << 16  |
+        (buf.get(pos + 4) & 0xff).toLong << 24  |
+        (buf.get(pos + 3) & 0xff).toLong << 32  |
+        (buf.get(pos + 2) & 0xff).toLong << 40  |
+        (buf.get(pos + 1) & 0xff).toLong << 48  |
+        BigInt((buf.get(pos) & 0xff).toLong) << 56
     pos += 8
 
     ret & unsignedLongMaxValue
@@ -426,7 +426,7 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
             (buf.get(pos + 4) & 0xff).toLong << 32 |
             (buf.get(pos + 5) & 0xff).toLong << 40 |
             (buf.get(pos + 6) & 0xff).toLong << 48 |
-      BigInt(buf.get(pos + 7) & 0xff) << 56
+            BigInt(buf.get(pos + 7) & 0xff) << 56
     pos += 8
 
     ret & unsignedLongMaxValue

--- a/util-core/src/main/scala/com/twitter/io/ByteReader.scala
+++ b/util-core/src/main/scala/com/twitter/io/ByteReader.scala
@@ -107,6 +107,16 @@ trait ByteReader extends AutoCloseable {
   def readLongLE(): Long
 
   /**
+    * Extract 64 bits and interpret as a big endian unsigned integer, advancing the byte cursor by 8.
+    */
+  def readUnsignedLongBE(): BigInt
+
+  /**
+    * Extract 64 bits and interpret as a little endian unsigned integer, advancing the byte cursor by 8.
+    */
+  def readUnsignedLongLE(): BigInt
+
+  /**
    * Extract 32 bits and interpret as a big endian floating point, advancing the byte cursor by 4.
    */
   def readFloatBE(): Float
@@ -186,6 +196,10 @@ private[twitter] trait ProxyByteReader extends ByteReader {
   def readLongBE(): Long = reader.readLongBE()
 
   def readLongLE(): Long = reader.readLongLE()
+
+  def readUnsignedLongBE(): BigInt = reader.readUnsignedLongBE()
+
+  def readUnsignedLongLE(): BigInt = reader.readUnsignedLongLE()
 
   def readFloatBE(): Float = reader.readFloatBE()
 
@@ -383,6 +397,31 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
     pos += 8
     ret
   }
+
+  private val unsignedLongMaxValue: BigInt = BigInt("18446744073709551615")
+
+  def readUnsignedLongBE(): BigInt = {
+    val arr = Array.ofDim[Byte](8)
+
+    for (i <- 0 until 8) {
+      val b = readByte()
+      arr(i) = b
+    }
+
+    BigInt(arr) & unsignedLongMaxValue
+  }
+
+  def readUnsignedLongLE(): BigInt = {
+    val arr = Array.ofDim[Byte](8)
+
+    for (i <- 0 until 8) {
+      val b = readByte()
+      arr(7 - i) = b
+    }
+
+    BigInt(arr) & unsignedLongMaxValue
+  }
+
 
   // - Floating Point -
   def readFloatBE(): Float = JFloat.intBitsToFloat(readIntBE())

--- a/util-core/src/main/scala/com/twitter/io/ByteReader.scala
+++ b/util-core/src/main/scala/com/twitter/io/ByteReader.scala
@@ -404,13 +404,13 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
     checkRemaining(8)
     val ret =
       BigInt(buf.get(pos    ) & 0xff) << 56 |
-      BigInt(buf.get(pos + 1) & 0xff) << 48 |
-      BigInt(buf.get(pos + 2) & 0xff) << 40 |
-      BigInt(buf.get(pos + 3) & 0xff) << 32 |
-      BigInt(buf.get(pos + 4) & 0xff) << 24 |
-      BigInt(buf.get(pos + 5) & 0xff) << 16 |
-      BigInt(buf.get(pos + 6) & 0xff) <<  8 |
-      BigInt(buf.get(pos + 7) & 0xff)
+            (buf.get(pos + 1) & 0xff).toLong << 48 |
+            (buf.get(pos + 2) & 0xff).toLong << 40 |
+            (buf.get(pos + 3) & 0xff).toLong << 32 |
+            (buf.get(pos + 4) & 0xff).toLong << 24 |
+            (buf.get(pos + 5) & 0xff).toLong << 16 |
+            (buf.get(pos + 6) & 0xff).toLong <<  8 |
+            (buf.get(pos + 7) & 0xff).toLong
     pos += 8
 
     ret & unsignedLongMaxValue
@@ -419,13 +419,13 @@ private class ByteReaderImpl(buf: Buf) extends ByteReader {
   def readUnsignedLongLE(): BigInt = {
     checkRemaining(8)
     val ret =
-      BigInt(buf.get(pos    ) & 0xff)       |
-      BigInt(buf.get(pos + 1) & 0xff) <<  8 |
-      BigInt(buf.get(pos + 2) & 0xff) << 16 |
-      BigInt(buf.get(pos + 3) & 0xff) << 24 |
-      BigInt(buf.get(pos + 4) & 0xff) << 32 |
-      BigInt(buf.get(pos + 5) & 0xff) << 40 |
-      BigInt(buf.get(pos + 6) & 0xff) << 48 |
+            (buf.get(pos    ) & 0xff).toLong       |
+            (buf.get(pos + 1) & 0xff).toLong <<  8 |
+            (buf.get(pos + 2) & 0xff).toLong << 16 |
+            (buf.get(pos + 3) & 0xff).toLong << 24 |
+            (buf.get(pos + 4) & 0xff).toLong << 32 |
+            (buf.get(pos + 5) & 0xff).toLong << 40 |
+            (buf.get(pos + 6) & 0xff).toLong << 48 |
       BigInt(buf.get(pos + 7) & 0xff) << 56
     pos += 8
 

--- a/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
@@ -1,7 +1,9 @@
 package com.twitter.io
 
 import java.lang.{Double => JDouble, Float => JFloat}
+
 import org.junit.runner.RunWith
+import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -152,6 +154,43 @@ class ByteReaderTest extends FunSuite with GeneratorDrivenPropertyChecks {
   test("readUnsignedIntLE") (forAll { i: Int =>
     val br = new ByteReaderImpl(Buf.Empty) { override def readIntLE() = i }
     assert(br.readUnsignedIntLE() == (i & 0xffffffffl))
+  })
+
+
+  val uInt64s : Gen[BigInt] = Gen.chooseNum(Long.MinValue,Long.MaxValue)
+    .map(x => BigInt(x) + BigInt(2).pow(63))
+
+  val range = for (i <- uInt64s) yield i
+
+  test("readUnsignedLongBE") (forAll(uInt64s) { bi: BigInt =>
+    val br = readerWith(
+      ((bi >> 56) & 0xff).toByte,
+      ((bi >> 48) & 0xff).toByte,
+      ((bi >> 40) & 0xff).toByte,
+      ((bi >> 32) & 0xff).toByte,
+      ((bi >> 24) & 0xff).toByte,
+      ((bi >> 16) & 0xff).toByte,
+      ((bi >>  8) & 0xff).toByte,
+      ((bi      ) & 0xff).toByte
+    )
+    assert(br.readUnsignedLongBE() == bi)
+    val exc = intercept[UnderflowException] { br.readByte() }
+  })
+
+  test("readUnsignedLongLE") (forAll(range) { bi1: BigInt =>
+    val bi = bi1.abs
+    val br = readerWith(
+      ((bi      ) & 0xff).toByte,
+      ((bi >>  8) & 0xff).toByte,
+      ((bi >> 16) & 0xff).toByte,
+      ((bi >> 24) & 0xff).toByte,
+      ((bi >> 32) & 0xff).toByte,
+      ((bi >> 40) & 0xff).toByte,
+      ((bi >> 48) & 0xff).toByte,
+      ((bi >> 56) & 0xff).toByte
+    )
+    assert(br.readUnsignedLongLE() == bi)
+    val exc = intercept[UnderflowException] { br.readByte() }
   })
 
   // .equals is required to handle NaN


### PR DESCRIPTION
Problem

readUnsignedLongBE and readUnsignedLongLE are missing in ByteReader implementation. finagle project needed that and as @vkostyukov stated, they're generally usefull, I moved that logic into ByteReader.

Solution

Added two functions 
`readUnsignedLongBE` and `readUnsignedLongLE` to ByteReader and implemented in ByteReaderImpl.
