### PR TITLE
util-core: AsyncStream.scanLeft is sometimes one element behind

### DIFF
--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -265,6 +265,13 @@ class AsyncStreamTest extends FunSuite with GeneratorDrivenPropertyChecks {
     assert(await(hd) == Some("hi"))
   }
 
+  test("scanLeft is eager for embed") {
+    val embed = AsyncStream.embed(Future.never)
+    val hd = embed.scanLeft("hi")((_, _) => ???).head
+    assert(hd.isDefined)
+    assert(await(hd) == Some("hi"))
+  }
+
   test("foldLeft") {
     forAll { (a: List[Int]) =>
       def f(s: String, n: Int) = (s.toLong + n).toString


### PR DESCRIPTION
Problem

AsyncStream.scanLeft is one element behind when the original
 AsyncStream is an Embed. The Embed case does not return the initial
 element until the wrapped future is done while other cases return
 the initial value before the Future is done.

Solution

Have the Embed case return the initial value without waiting for the
 future and call a new method, scanLeftEmbed, on the nested AsyncStream.
 scanLeftEmbed which does not return the initial value and thus prevent
 duplicate values from being returned.

Result

scanLeft is now fully eager.