### PR TITLE
Fixed possible ArrayIndexOutOfBoundException of Logger

### DIFF
--- a/util-logging/src/main/scala/com/twitter/logging/Logger.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/Logger.scala
@@ -402,8 +402,15 @@ object Logger extends Iterable[Logger] {
   /** An alias for `get(name)` */
   def apply(name: String) = get(name)
 
-  private def get(depth: Int): Logger =
-    getForClassName(new Throwable().getStackTrace()(depth).getClassName)
+  private def get(depth: Int): Logger = {
+    val st = new Throwable().getStackTrace
+    if (st.length >= depth) {
+      getForClassName(st(depth).getClassName)
+    } else {
+      // Seems like there is no stack trace in throwable, possibly the JVM is running with `-XX:-StackTraceInThrowable` option
+      getForClassName("stackTraceIsAbsent")
+    }
+  }
 
   /**
    * Return a logger for the class name of the class/object that called


### PR DESCRIPTION
Problem

It is not safe to assume that stack traces are always available, one might run JVM with `-XX:-StackTraceInThrowable` option.

Solution

I've added boundary check, if there is no stack traces in throwables, simply fall back to some constant name

Result

Finagle will stop failing startup  :)
