### PR TITLE
Return Future.never for Future.Sleep(Duration.Top)

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -140,6 +140,7 @@ object Future {
    */
   def sleep(howlong: Duration)(implicit timer: Timer): Future[Unit] =
     if (howlong <= Duration.Zero) Future.Done
+    else if (howlong == Duration.Top) Future.never
     else
       new Promise[Unit] with Promise.InterruptHandler with (() => Unit) {
         private[this] val task = timer.schedule(howlong.fromNow)(this())

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -1738,8 +1738,8 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
     "Be interruptible" in {
       implicit val timer = new MockTimer
 
-      // sleep forever and grab the task that's created
-      val f = Future.sleep(Duration.Top)(timer)
+      // sleep and grab the task that's created
+      val f = Future.sleep(1.second)(timer)
       val task = timer.tasks(0)
       // then raise a known exception
       val e = new Exception("expected")
@@ -1754,6 +1754,12 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
       implicit val timer = new MockTimer
       assert(Future.sleep(Duration.Zero) eq Future.Done)
       assert(Future.sleep((-10).seconds) eq Future.Done)
+      assert(timer.tasks.isEmpty)
+    }
+
+    "Return Future.never for Duration.Top" in {
+      implicit val timer = new MockTimer
+      assert(Future.sleep(Duration.Top) eq Future.never)
       assert(timer.tasks.isEmpty)
     }
   }


### PR DESCRIPTION
Problem

Calling Future.Sleep with extremely large values (including Duration.Top) can sometimes return a Future that is satisfied immediately due to overflow in the underlying Timer implementation.

Solution

Since Duration.Top is a special value, we just return Future.never.

Result

Calling Future.sleep with Duration.Top will return a Future that never completes.  Depending on the Timer implementation, calling Future.sleep with other extremely large values can still return a Future that completes immediately.
