### PR TITLE
fix procedure syntax

### DIFF
--- a/util-benchmark/src/main/scala/com/twitter/concurrent/OfferBenchmark.scala
+++ b/util-benchmark/src/main/scala/com/twitter/concurrent/OfferBenchmark.scala
@@ -12,7 +12,7 @@ class OfferBenchmark {
   import OfferBenchmark._
 
   @Benchmark
-  def timeChoose(state: OfferBenchmarkState) {
+  def timeChoose(state: OfferBenchmarkState): Unit = {
     val offers = state.toChooseFrom()
     Offer.choose(state.rngOpt, offers).prepare()
   }

--- a/util-benchmark/src/main/scala/com/twitter/jvm/CpuProfile.scala
+++ b/util-benchmark/src/main/scala/com/twitter/jvm/CpuProfile.scala
@@ -11,18 +11,18 @@ class CpuProfileBenchmark {
   import CpuProfileBenchmark._
 
   @Benchmark
-  def timeThreadGetStackTraces(state: ThreadState) {
+  def timeThreadGetStackTraces(state: ThreadState): Unit = {
     Thread.getAllStackTraces()
   }
 
   @Benchmark
-  def timeThreadInfoBare(state: ThreadState) {
+  def timeThreadInfoBare(state: ThreadState): Unit = {
     state.bean.dumpAllThreads(false, false)
   }
 
   // Note: we should actually simulate some contention, too.
   @Benchmark
-  def timeThreadInfoFull(state: ThreadState) {
+  def timeThreadInfoFull(state: ThreadState): Unit = {
     state.bean.dumpAllThreads(true, true)
   }
 }
@@ -57,12 +57,12 @@ object CpuProfileBenchmark {
     val rngSeed = 131451732492626L
 
     @Setup(Level.Iteration)
-    def setUp() {
+    def setUp(): Unit = {
       val stack = new Stack(new Random(rngSeed), stackMeanSize, stackStddev)
       threads = for (_ <- 0 until nthreads)
         yield
           new Thread {
-            override def run() {
+            override def run(): Unit = {
               try stack()
               catch {
                 case _: InterruptedException =>
@@ -76,7 +76,7 @@ object CpuProfileBenchmark {
     }
 
     @TearDown(Level.Iteration)
-    def tearDown() {
+    def tearDown(): Unit = {
       threads foreach { t =>
         t.interrupt()
       }

--- a/util-benchmark/src/main/scala/com/twitter/util/PromiseBenchmark.scala
+++ b/util-benchmark/src/main/scala/com/twitter/util/PromiseBenchmark.scala
@@ -16,7 +16,7 @@ class PromiseBenchmark extends StdBenchAnnotations {
   }
 
   @Benchmark
-  def detach(state: PromiseBenchmark.PromiseDetachState) {
+  def detach(state: PromiseBenchmark.PromiseDetachState): Unit = {
     import state._
     promise.detach()
   }

--- a/util-cache/src/main/scala/com/twitter/cache/EvictingCache.scala
+++ b/util-cache/src/main/scala/com/twitter/cache/EvictingCache.scala
@@ -11,7 +11,7 @@ private[cache] class EvictingCache[K, V](underlying: FutureCache[K, V])
     f // we return the original future to make evict(k, f) easier to work with.
   }
 
-  override def set(k: K, v: Future[V]) {
+  override def set(k: K, v: Future[V]): Unit = {
     super.set(k, v)
     evictOnFailure(k, v)
   }

--- a/util-cache/src/main/scala/com/twitter/cache/FutureCache.scala
+++ b/util-cache/src/main/scala/com/twitter/cache/FutureCache.scala
@@ -37,7 +37,7 @@ abstract class FutureCache[K, V] {
   /**
    * Unconditionally sets a value for a given key
    */
-  def set(key: K, value: Future[V])
+  def set(key: K, value: Future[V]): Unit
 
   /**
    * Evicts the contents of a `key` if the old value is `value`.

--- a/util-codec/src/test/scala/com/twitter/util/StringEncoderTest.scala
+++ b/util-codec/src/test/scala/com/twitter/util/StringEncoderTest.scala
@@ -64,7 +64,7 @@ class GZIPStringEncoderTest extends WordSpec {
   "a gzip string encoder" should {
     val gse = new GZIPStringEncoder {}
     "properly encode and decode strings" in {
-      def testCodec(str: String) {
+      def testCodec(str: String): Unit = {
         assert(str == gse.decodeString(gse.encodeString(str)))
       }
 

--- a/util-collection/src/main/scala/com/twitter/collection/GenerationalQueue.scala
+++ b/util-collection/src/main/scala/com/twitter/collection/GenerationalQueue.scala
@@ -5,9 +5,9 @@ import scala.collection._
 import com.twitter.util.{Duration, Time}
 
 trait GenerationalQueue[A] {
-  def touch(a: A)
-  def add(a: A)
-  def remove(a: A)
+  def touch(a: A): Unit
+  def add(a: A): Unit
+  def remove(a: A): Unit
   def collect(d: Duration): Option[A]
   def collectAll(d: Duration): Iterable[A]
 }
@@ -117,7 +117,7 @@ class BucketGenerationalQueue[A](timeout: Duration) extends GenerationalQueue[A]
     }
   }
 
-  private[this] def updateBuckets() {
+  private[this] def updateBuckets(): Unit = {
     if (maybeGrowChain())
       buckets = compactChain()
   }

--- a/util-collection/src/main/scala/com/twitter/util/LruMap.scala
+++ b/util-collection/src/main/scala/com/twitter/util/LruMap.scala
@@ -24,7 +24,7 @@ trait JMapWrapperLike[A, B, +Repr <: MapLike[A, B, Repr] with Map[A, B]]
 
   override def put(k: A, v: B): Option[B] = underlying.asScala.put(k, v)
 
-  override def update(k: A, v: B) { underlying.put(k, v) }
+  override def update(k: A, v: B): Unit = { underlying.put(k, v) }
 
   override def remove(k: A): Option[B] = underlying.asScala.remove(k)
 

--- a/util-collection/src/test/scala/com/twitter/collection/GenerationalQueueTest.scala
+++ b/util-collection/src/test/scala/com/twitter/collection/GenerationalQueueTest.scala
@@ -14,7 +14,7 @@ class GenerationalQueueTest extends FunSuite {
     name: String,
     newQueue: () => GenerationalQueue[String],
     timeout: Duration
-  ) {
+  ): Unit = {
 
     test("%s: Don't collect fresh data".format(name)) {
       Time.withCurrentTimeFrozen { _ =>

--- a/util-core/src/main/scala/com/twitter/concurrent/Broker.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Broker.scala
@@ -40,7 +40,7 @@ class Broker[T] {
   private[this] val state = new AtomicReference[State](Quiet)
 
   @tailrec
-  private[this] def rmElem(elem: AnyRef) {
+  private[this] def rmElem(elem: AnyRef): Unit = {
     state.get match {
       case s @ Sending(q) =>
         val nextq = q filter { _ ne elem }

--- a/util-core/src/main/scala/com/twitter/concurrent/Offer.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Offer.scala
@@ -136,7 +136,7 @@ trait Offer[+T] { self =>
    * with each successfully synchronized value.  A receiver can use
    * this to enumerate over all received values.
    */
-  def foreach(f: T => Unit) {
+  def foreach(f: T => Unit): Unit = {
     sync().foreach { v =>
       f(v)
       foreach(f)
@@ -147,7 +147,7 @@ trait Offer[+T] { self =>
    * Synchronize (discarding the value), and then invoke the given
    * closure.  Convenient for loops.
    */
-  def andThen(f: => Unit) {
+  def andThen(f: => Unit): Unit = {
     sync().respond {
       case Return(_) => f
       case _ =>

--- a/util-core/src/main/scala/com/twitter/concurrent/Scheduler.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Scheduler.scala
@@ -366,7 +366,7 @@ class BridgedThreadPoolScheduler(
       local.submit(r)
     else
       try executor.execute(new Runnable {
-        def run() {
+        def run(): Unit = {
           BridgedThreadPoolScheduler.this.submit(r)
         }
       })

--- a/util-core/src/main/scala/com/twitter/concurrent/Serialized.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Serialized.scala
@@ -14,7 +14,7 @@ import com.twitter.util.{Future, Promise, Try}
  */
 trait Serialized {
   protected case class Job[T](promise: Promise[T], doItToIt: () => T) {
-    def apply() {
+    def apply(): Unit = {
       promise.update { Try { doItToIt() } }
     }
   }

--- a/util-core/src/main/scala/com/twitter/concurrent/SpoolSource.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/SpoolSource.scala
@@ -51,7 +51,7 @@ class SpoolSource[A](interruptHandler: PartialFunction[Throwable, Unit]) {
    * If multiple threads call `offer` simultaneously, the operation is thread-safe but
    * the resulting order of values in the spool is non-deterministic.
    */
-  final def offer(value: A) {
+  final def offer(value: A): Unit = {
 
     val nextPromise = new Promise[Spool[A]]
     nextPromise.setInterruptHandler(interruptHandler)
@@ -69,7 +69,7 @@ class SpoolSource[A](interruptHandler: PartialFunction[Throwable, Unit]) {
    * thread-safe but the resulting order of values in the spool is
    * non-deterministic.
    */
-  final def offerAndClose(value: A) {
+  final def offerAndClose(value: A): Unit = {
 
     updatingTailCall(emptyPromise) { currentPromise =>
       currentPromise.setValue(value *:: Future.value(Spool.empty[A]))
@@ -81,7 +81,7 @@ class SpoolSource[A](interruptHandler: PartialFunction[Throwable, Unit]) {
    * Closes this SpoolSource, which also terminates the generated Spool.  This method
    * is idempotent.
    */
-  final def close() {
+  final def close(): Unit = {
     updatingTailCall(emptyPromise) { currentPromise =>
       currentPromise.setValue(Spool.empty[A])
       closedp.setDone()
@@ -98,7 +98,7 @@ class SpoolSource[A](interruptHandler: PartialFunction[Throwable, Unit]) {
    * Raises exception on this SpoolSource, which also terminates the generated Spool.  This method
    * is idempotent.
    */
-  final def raise(e: Throwable) {
+  final def raise(e: Throwable): Unit = {
     updatingTailCall(emptyPromise) { currentPromise =>
       currentPromise.setException(e)
       closedp.setException(e)
@@ -106,7 +106,7 @@ class SpoolSource[A](interruptHandler: PartialFunction[Throwable, Unit]) {
   }
 
   @tailrec
-  private[this] def updatingTailCall(newPromise: Promise[Spool[A]])(f: Promise[Spool[A]] => Unit) {
+  private[this] def updatingTailCall(newPromise: Promise[Spool[A]])(f: Promise[Spool[A]] => Unit): Unit = {
     val currentPromise = promiseRef.get
     // if the current promise is emptyPromise, then this source has already been closed
     if (currentPromise ne emptyPromise) {

--- a/util-core/src/main/scala/com/twitter/concurrent/Tx.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Tx.scala
@@ -28,7 +28,7 @@ trait Tx[+T] {
    * Abort the transaction. It is invalid to abort a transaction after
    * acknowledging it.
    */
-  def nack()
+  def nack(): Unit
 }
 
 /**
@@ -44,7 +44,7 @@ object Tx {
    */
   val aborted: Tx[Nothing] = new Tx[Nothing] {
     def ack() = Future.value(Abort)
-    def nack() {}
+    def nack(): Unit = {}
   }
 
   /**
@@ -54,7 +54,7 @@ object Tx {
    */
   def const[T](msg: T): Tx[T] = new Tx[T] {
     def ack() = Future.value(Commit(msg))
-    def nack() {}
+    def nack(): Unit = {}
   }
 
   /**
@@ -117,7 +117,7 @@ object Tx {
         }
       }
 
-      def nack() {
+      def nack(): Unit = {
         lock.synchronized {
           state match {
             case Idle => state = Nackd(this)

--- a/util-core/src/main/scala/com/twitter/io/BufInputStream.scala
+++ b/util-core/src/main/scala/com/twitter/io/BufInputStream.scala
@@ -22,7 +22,7 @@ class BufInputStream(val buf: Buf) extends InputStream {
   override def available(): Int = synchronized { length - index }
 
   // Closing a BufInputStream has no effect.
-  override def close() {}
+  override def close(): Unit = {}
 
   // Marks the current position in this input stream.
   override def mark(readlimit: Int) = synchronized { mrk = index }

--- a/util-core/src/main/scala/com/twitter/util/Base64Long.scala
+++ b/util-core/src/main/scala/com/twitter/util/Base64Long.scala
@@ -74,7 +74,7 @@ object Base64Long {
    * The number is treated as unsigned, so there is never a leading negative sign, and the
    * representations of negative numbers are larger than positive numbers.
    */
-  def toBase64(builder: StringBuilder, l: Long, alphabet: Int => Char = StandardBase64Alphabet) {
+  def toBase64(builder: StringBuilder, l: Long, alphabet: Int => Char = StandardBase64Alphabet): Unit = {
     if (l == 0) {
       // Special case for zero: Just like in decimal, if the number is
       // zero, represent it as a single zero digit.

--- a/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -39,12 +39,12 @@ private[util] class BatchExecutor[In, Out](
     @volatile var cancelled = false
     val task = timer.schedule(after.fromNow) { flush() }
 
-    def cancel() {
+    def cancel(): Unit = {
       cancelled = true
       task.cancel()
     }
 
-    def flush() {
+    def flush(): Unit = {
       val doAfter = batcher.synchronized {
         if (!cancelled)
           flushBatch()
@@ -108,7 +108,7 @@ private[util] class BatchExecutor[In, Out](
     doAfter()
   }
 
-  def scheduleFlushIfNecessary() {
+  def scheduleFlushIfNecessary(): Unit = {
     if (timeThreshold < Duration.Top && scheduled.isEmpty)
       scheduled = Some(new ScheduledFlush(timeThreshold, timer))
   }
@@ -132,7 +132,7 @@ private[util] class BatchExecutor[In, Out](
       }
   }
 
-  def executeBatch(batch: Seq[(In, Promise[Out])]) {
+  def executeBatch(batch: Seq[(In, Promise[Out])]): Unit = {
     val uncancelled = batch filter {
       case (in, p) =>
         p.isInterrupted match {

--- a/util-core/src/main/scala/com/twitter/util/BoundedStack.scala
+++ b/util-core/src/main/scala/com/twitter/util/BoundedStack.scala
@@ -14,7 +14,7 @@ class BoundedStack[A: ClassTag](val maxSize: Int) extends Seq[A] {
   def length = count_
   override def size = count_
 
-  def clear() {
+  def clear(): Unit = {
     top = 0
     count_ = 0
   }
@@ -30,7 +30,7 @@ class BoundedStack[A: ClassTag](val maxSize: Int) extends Seq[A] {
   /**
    * Pushes an element, possibly forcing out the oldest element in the stack.
    */
-  def +=(elem: A) {
+  def +=(elem: A): Unit = {
     top = if (top == 0) maxSize - 1 else top - 1
     array(top) = elem
     if (count_ < maxSize) count_ += 1
@@ -41,7 +41,7 @@ class BoundedStack[A: ClassTag](val maxSize: Int) extends Seq[A] {
    * of 0 is the same as calling this += elem.  This is a O(n) operation
    * as elements need to be shifted around.
    */
-  def insert(i: Int, elem: A) {
+  def insert(i: Int, elem: A): Unit = {
     if (i == 0) this += elem
     else if (i > count_) throw new IndexOutOfBoundsException(i.toString)
     else if (i == count_) {
@@ -57,7 +57,7 @@ class BoundedStack[A: ClassTag](val maxSize: Int) extends Seq[A] {
   /**
    * Replaces an element in the stack.
    */
-  def update(index: Int, elem: A) {
+  def update(index: Int, elem: A): Unit = {
     array((top + index) % maxSize) = elem
   }
 
@@ -67,7 +67,7 @@ class BoundedStack[A: ClassTag](val maxSize: Int) extends Seq[A] {
    * stack can hold, then only the last maxSize elements will end up in
    * the stack.
    */
-  def ++=(iter: Iterable[A]) {
+  def ++=(iter: Iterable[A]): Unit = {
     for (elem <- iter) this += elem
   }
 

--- a/util-core/src/main/scala/com/twitter/util/Cancellable.scala
+++ b/util-core/src/main/scala/com/twitter/util/Cancellable.scala
@@ -19,7 +19,7 @@ trait Cancellable {
    * Cancel the computation.  The cancellation is propagated to linked
    * cancellable objects.
    */
-  def cancel()
+  def cancel(): Unit
 
   /**
    * Link this cancellable computation to 'other'.  This means
@@ -31,16 +31,16 @@ trait Cancellable {
 object Cancellable {
   val nil: Cancellable = new Cancellable {
     def isCancelled = false
-    def cancel() {}
-    def linkTo(other: Cancellable) {}
+    def cancel(): Unit = {}
+    def linkTo(other: Cancellable): Unit = {}
   }
 }
 
 class CancellableSink(f: => Unit) extends Cancellable {
   private[this] val wasCancelled = new AtomicBoolean(false)
   def isCancelled = wasCancelled.get
-  def cancel() { if (wasCancelled.compareAndSet(false, true)) f }
-  def linkTo(other: Cancellable) {
+  def cancel(): Unit = { if (wasCancelled.compareAndSet(false, true)) f }
+  def linkTo(other: Cancellable): Unit = {
     throw new Exception("linking not supported in CancellableSink")
   }
 }

--- a/util-core/src/main/scala/com/twitter/util/Closable.scala
+++ b/util-core/src/main/scala/com/twitter/util/Closable.scala
@@ -159,7 +159,7 @@ object Closable {
   private val refq = new ReferenceQueue[Object]
 
   private val collectorThread = new Thread("CollectClosables") {
-    override def run() {
+    override def run(): Unit = {
       while (true) {
         try {
           val ref = refq.remove()

--- a/util-core/src/main/scala/com/twitter/util/Disposable.scala
+++ b/util-core/src/main/scala/com/twitter/util/Disposable.scala
@@ -84,7 +84,7 @@ trait Managed[+T] { selfT =>
    * Create a new T, and pass it to the given operation (f).
    * After it completes, the resource is disposed.
    */
-  def foreach(f: T => Unit) {
+  def foreach(f: T => Unit): Unit = {
     val r = this.make()
     try f(r.get)
     finally r.dispose()

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -1994,7 +1994,7 @@ abstract class Future[+A] extends Awaitable[A] { self =>
    *
    * @see [[com.twitter.util.Promise.become]]
    */
-  def proxyTo[B >: A](other: Promise[B]) {
+  def proxyTo[B >: A](other: Promise[B]): Unit = {
     if (other.isDefined) {
       throw new IllegalStateException(
         s"Cannot call proxyTo on an already satisfied Promise: ${Await.result(other.liftToTry)}"

--- a/util-core/src/main/scala/com/twitter/util/LastWriteWinsQueue.scala
+++ b/util-core/src/main/scala/com/twitter/util/LastWriteWinsQueue.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicReference
 class LastWriteWinsQueue[A] extends java.util.Queue[A] {
   val item = new AtomicReference[Option[A]](None)
 
-  def clear() {
+  def clear(): Unit = {
     item.set(None)
   }
 

--- a/util-core/src/main/scala/com/twitter/util/Signal.scala
+++ b/util-core/src/main/scala/com/twitter/util/Signal.scala
@@ -28,7 +28,7 @@ object SignalHandlerFactory {
 }
 
 trait SignalHandler {
-  def handle(signal: String, handlers: Map[String, Set[String => Unit]])
+  def handle(signal: String, handlers: Map[String, Set[String => Unit]]): Unit
 }
 
 object SunSignalHandler {
@@ -48,7 +48,7 @@ class SunSignalHandler extends SignalHandler {
   private val handleMethod = signalClass.getMethod("handle", signalClass, signalHandlerClass)
   private val nameMethod = signalClass.getMethod("getName")
 
-  def handle(signal: String, handlers: Map[String, Set[String => Unit]]) {
+  def handle(signal: String, handlers: Map[String, Set[String => Unit]]): Unit = {
     val sunSignal =
       signalClass.getConstructor(classOf[String]).newInstance(signal).asInstanceOf[Object]
     val proxy = Proxy
@@ -79,7 +79,7 @@ object HandleSignal {
    * Set the callback function for a named unix signal.
    * For now, this only works on the Sun^H^H^HOracle JVM.
    */
-  def apply(posixSignal: String)(f: String => Unit) {
+  def apply(posixSignal: String)(f: String => Unit): Unit = {
     if (!handlers.contains(posixSignal)) {
       handlers.synchronized {
         SignalHandlerFactory().foreach { _.handle(posixSignal, handlers) }
@@ -92,7 +92,7 @@ object HandleSignal {
     }
   }
 
-  def clear(posixSignal: String) {
+  def clear(posixSignal: String): Unit = {
     handlers.synchronized {
       handlers(posixSignal).clear()
     }

--- a/util-core/src/main/scala/com/twitter/util/TempFolder.scala
+++ b/util-core/src/main/scala/com/twitter/util/TempFolder.scala
@@ -38,7 +38,7 @@ trait TempFolder {
    *
    * Use of this function may not be nested.
    */
-  def withTempFolder(f: => Any) {
+  def withTempFolder(f: => Any): Unit = {
     val tempFolder = System.getProperty("java.io.tmpdir")
     // Note: If we were willing to have a dependency on Guava in util-core
     // we could just use `com.google.common.io.Files.createTempDir()`

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -495,8 +495,8 @@ object Time extends TimeLikeOps[Time] {
 }
 
 trait TimeControl {
-  def set(time: Time)
-  def advance(delta: Duration)
+  def set(time: Time): Unit
+  def advance(delta: Duration): Unit
 }
 
 /**

--- a/util-core/src/main/scala/com/twitter/util/Try.scala
+++ b/util-core/src/main/scala/com/twitter/util/Try.scala
@@ -133,7 +133,7 @@ sealed abstract class Try[+R] {
   /**
    * Applies the given function f if this is a Result.
    */
-  def foreach(f: R => Unit) { onSuccess(f) }
+  def foreach(f: R => Unit): Unit = { onSuccess(f) }
 
   /**
    * Returns the given function applied to the value from this Return or returns this if this is a Throw.

--- a/util-core/src/test/scala/com/twitter/concurrent/SerializedTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SerializedTest.scala
@@ -14,7 +14,7 @@ class SerializedTest extends WordSpec with Serialized {
       val orderOfExecution = new collection.mutable.ListBuffer[Thread]
 
       val t1 = new Thread {
-        override def run {
+        override def run: Unit = {
           serialized {
             t1CallsSerializedFirst.countDown()
             t1FinishesWork.await()
@@ -25,7 +25,7 @@ class SerializedTest extends WordSpec with Serialized {
       }
 
       val t2 = new Thread {
-        override def run {
+        override def run: Unit = {
           t1CallsSerializedFirst.await()
           serialized {
             orderOfExecution += this

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -808,7 +808,7 @@ class BufTest
   }
 
   test("hash code, equals") {
-    def ae(a: Buf, b: Buf) {
+    def ae(a: Buf, b: Buf): Unit = {
       assert(a == b)
       assert(a.hashCode == b.hashCode)
     }

--- a/util-core/src/test/scala/com/twitter/util/CloseAwaitablyTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/CloseAwaitablyTest.scala
@@ -41,7 +41,7 @@ class CloseAwaitablyTest extends FunSuite {
     val c = make()
     val t = new Thread {
       start()
-      override def run() {
+      override def run(): Unit = {
         Await.ready(c)
       }
     }

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 @RunWith(classOf[JUnitRunner])
 class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenPropertyChecks {
   implicit class FutureMatcher[A](future: Future[A]) {
-    def mustProduce(expected: Try[A]) {
+    def mustProduce(expected: Try[A]): Unit = {
       expected match {
         case Throw(ex) =>
           val t = intercept[Throwable] {
@@ -58,7 +58,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
     def exception[A](exc: Throwable): Future[A] = this(Throw(exc))
   }
 
-  def test(name: String, const: MkConst) {
+  def test(name: String, const: MkConst): Unit = {
     "object Future (%s)".format(name) when {
       "times" should {
         trait TimesHelper {
@@ -411,7 +411,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
           Time.withCurrentTimeFrozen { control =>
             val blocker = new Promise[Unit]
             val thread = new Thread {
-              override def run() {
+              override def run(): Unit = {
                 when(f(result)) thenReturn (Future.value(Seq(7, 8, 9)))
                 batcher(4)
                 batcher(5)
@@ -735,7 +735,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
         }
       }
 
-      def testJoin(label: String, joiner: ((Future[Int], Future[Int]) => Future[(Int, Int)])) {
+      def testJoin(label: String, joiner: ((Future[Int], Future[Int]) => Future[(Int, Int)])): Unit = {
         "join(%s)".format(label) should {
           trait JoinHelper {
             val p0 = new HandledPromise[Int]
@@ -1064,7 +1064,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
         }
       }
 
-      def testSequence(which: String, seqop: (Future[Unit], () => Future[Unit]) => Future[Unit]) {
+      def testSequence(which: String, seqop: (Future[Unit], () => Future[Unit]) => Future[Unit]): Unit = {
         which when {
           "successes" should {
             "interruption of the produced future" which {
@@ -1377,7 +1377,7 @@ class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenProperty
         }
 
         val t = new Thread {
-          override def run() {
+          override def run(): Unit = {
             local() = 1010
             promise() = Return(local())
           }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -111,7 +111,7 @@ class PromiseTest extends FunSuite {
   }
 
   // this won't work inline, because we still hold a reference to d
-  def detach(d: Promise.Detachable) {
+  def detach(d: Promise.Detachable): Unit = {
     assert(d != null)
     assert(d.detach())
   }

--- a/util-core/src/test/scala/com/twitter/util/StateMachineTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/StateMachineTest.scala
@@ -13,7 +13,7 @@ class StateMachineTest extends WordSpec {
         case class State2() extends State
         state = State1()
 
-        def command1() {
+        def command1(): Unit = {
           transition("command1") {
             case State1() => state = State2()
           }

--- a/util-core/src/test/scala/com/twitter/util/TimeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimeTest.scala
@@ -451,7 +451,7 @@ with IntegrationPatience {
         assert(Time.now == t0)
         @volatile var threadTime: Option[Time] = None
         val thread = new Thread {
-          override def run() {
+          override def run(): Unit = {
             threadTime = Some(Time.now)
           }
         }
@@ -500,7 +500,7 @@ with IntegrationPatience {
       Time.withCurrentTimeFrozen { ctl =>
         val ctx = Local.save()
         val r = new Runnable {
-          def run() {
+          def run(): Unit = {
             Local.restore(ctx)
             Time.sleep(5.seconds)
           }

--- a/util-core/src/test/scala/com/twitter/util/TimerTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimerTest.scala
@@ -130,7 +130,7 @@ class TimerTest extends FunSuite with MockitoSugar with Eventually with Integrat
     var latch = new CountDownLatch(1)
 
     val timer = new JavaTimer {
-      override def logError(t: Throwable) {
+      override def logError(t: Throwable): Unit = {
         errors += 1
         latch.countDown()
       }

--- a/util-hashing/src/main/scala/com/twitter/hashing/Hashable.scala
+++ b/util-hashing/src/main/scala/com/twitter/hashing/Hashable.scala
@@ -252,7 +252,7 @@ object Hashable extends LowPriorityHashable {
 
       def rot(x: Int, k: Int) = (((x) << (k)) | ((x) >> (32 - (k))))
 
-      def mix() {
+      def mix(): Unit = {
         a -= c; a ^= rot(c, 4); c += b
         b -= a; b ^= rot(a, 6); a += c
         c -= b; c ^= rot(b, 8); b += a
@@ -261,7 +261,7 @@ object Hashable extends LowPriorityHashable {
         c -= b; c ^= rot(b, 4); b += a
       }
 
-      def fin() {
+      def fin(): Unit = {
         c ^= b; c -= rot(b, 14); a ^= c; a -= rot(c, 11)
         b ^= a; b -= rot(a, 25); c ^= b; c -= rot(b, 16)
         a ^= c; a -= rot(c, 4); b ^= a; b -= rot(a, 14)

--- a/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
@@ -20,7 +20,7 @@ class HashableTest extends FunSuite with GeneratorDrivenPropertyChecks {
     Hashable.MURMUR3
   )
 
-  def testConsistency[T](algo: Hashable[Array[Byte], T]) {
+  def testConsistency[T](algo: Hashable[Array[Byte], T]): Unit = {
     forAll { input: Array[Byte] =>
       assert(algo(input) == algo(input))
     }

--- a/util-jvm/src/main/scala/com/twitter/jvm/CpuProfile.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/CpuProfile.scala
@@ -29,18 +29,18 @@ case class CpuProfile(
    *
    *   http://google-perftools.googlecode.com/svn/trunk/doc/cpuprofile-fileformat.html
    */
-  def writeGoogleProfile(out: OutputStream) {
+  def writeGoogleProfile(out: OutputStream): Unit = {
     var next = 1
     val uniq = mutable.HashMap[StackTraceElement, Int]()
     val word = ByteBuffer.allocate(8)
     word.order(ByteOrder.LITTLE_ENDIAN)
-    def putWord(n: Long) {
+    def putWord(n: Long): Unit = {
       word.clear()
       word.putLong(n)
       out.write(word.array())
     }
 
-    def putString(s: String) {
+    def putString(s: String): Unit = {
       out.write(s.getBytes)
     }
 
@@ -163,7 +163,7 @@ object CpuProfile {
   def recordInThread(howlong: Duration, frequency: Int, state: Thread.State): Future[CpuProfile] = {
     val p = new Promise[CpuProfile]
     val thr = new Thread("CpuProfile") {
-      override def run() {
+      override def run(): Unit = {
         p.setValue(record(howlong, frequency, state))
       }
     }

--- a/util-jvm/src/main/scala/com/twitter/jvm/Estimator.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Estimator.scala
@@ -8,7 +8,7 @@ import scala.util.Random
 trait Estimator[T] {
 
   /** A scalar measurement `m` was taken */
-  def measure(m: T)
+  def measure(m: T): Unit
 
   /** Estimate the current value */
   def estimate: T
@@ -28,7 +28,7 @@ class Kalman(N: Int) {
    * Update the filter with measurement `m`
    * and measurement error `e`.
    */
-  def measure(m: Double, e: Double) {
+  def measure(m: Double, e: Double): Unit = {
     val i = (n % N).toInt
     mbuf(i) = m
     ebuf(i) = e
@@ -83,7 +83,7 @@ class KalmanGaussianError(N: Int, range: Double) extends Kalman(N) with Estimato
   require(range >= 0D && range < 1D)
   private[this] val rng = new Random
 
-  def measure(m: Double) {
+  def measure(m: Double): Unit = {
     measure(m, rng.nextGaussian() * range * m)
   }
 }
@@ -115,7 +115,7 @@ class WindowedMeans(N: Int, windows: Seq[(Int, Int)]) extends Estimator[Double] 
     sum / count
   }
 
-  def measure(m: Double) {
+  def measure(m: Double): Unit = {
     if (n == 0)
       java.util.Arrays.fill(buf, m)
     else
@@ -140,7 +140,7 @@ class LoadAverage(interval: Double) extends Estimator[Double] {
   private[this] val a = math.exp(-1D / interval)
   private[this] var load = Double.NaN
 
-  def measure(m: Double) {
+  def measure(m: Double): Unit = {
     load =
       if (load.isNaN) m
       else load * a + m * (1 - a)

--- a/util-jvm/src/main/scala/com/twitter/jvm/GcPredictor.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/GcPredictor.scala
@@ -10,7 +10,7 @@ import com.twitter.util.{Duration, Time, Timer}
  * the rate estimated by `estimator`.
  */
 class GcPredictor(pool: Pool, period: Duration, timer: Timer, estimator: Estimator[Double]) {
-  private[this] def loop() {
+  private[this] def loop(): Unit = {
     for (bps <- pool.estimateAllocRate(period, timer)) {
       synchronized { estimator.measure(bps.toDouble) }
       loop()

--- a/util-jvm/src/main/scala/com/twitter/jvm/Heapster.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Heapster.scala
@@ -32,10 +32,10 @@ class Heapster(klass: Class[_]) {
   private val setSamplingPeriodM =
     klass.getDeclaredMethod("setSamplingPeriod", classOf[java.lang.Integer])
 
-  def start() { startM.invoke(null) }
-  def shutdown() { stopM.invoke(null) }
-  def setSamplingPeriod(period: java.lang.Integer) { setSamplingPeriodM.invoke(null, period) }
-  def clearProfile() { clearProfileM.invoke(null) }
+  def start(): Unit = { startM.invoke(null) }
+  def shutdown(): Unit = { stopM.invoke(null) }
+  def setSamplingPeriod(period: java.lang.Integer): Unit = { setSamplingPeriodM.invoke(null, period) }
+  def clearProfile(): Unit = { clearProfileM.invoke(null) }
   def dumpProfile(forceGC: java.lang.Boolean): Array[Byte] =
     dumpProfileM.invoke(null, forceGC).asInstanceOf[Array[Byte]]
 

--- a/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
@@ -153,7 +153,7 @@ trait Jvm {
    * same is true of the internal datastructures used by foreachGc,
    * but they are svelte.
    */
-  def foreachGc(f: Gc => Unit) {
+  def foreachGc(f: Gc => Unit): Unit = {
     val Period = 1.second
     val LogPeriod = 30.minutes
     @volatile var missedCollections = 0L

--- a/util-jvm/src/test/scala/com/twitter/jvm/ContentionTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/ContentionTest.scala
@@ -35,12 +35,12 @@ class ContentionTest extends FunSuite with Eventually {
     val plato = new Philosopher()
 
     val d = new Thread(new Runnable() {
-      def run() { descartes.dine(plato) }
+      def run(): Unit = { descartes.dine(plato) }
     })
     d.start()
 
     val p = new Thread(new Runnable() {
-      def run() { plato.dine(descartes) }
+      def run(): Unit = { plato.dine(descartes) }
     })
     p.start()
     Await.all(descartes.ready, plato.ready)

--- a/util-jvm/src/test/scala/com/twitter/jvm/CpuProfileTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/CpuProfileTest.scala
@@ -18,7 +18,7 @@ class CpuProfileTest extends FunSuite {
     def nextTime: Time = start + iter.next().milliseconds * 10
 
     val t = new Thread("CpuProfileTest") {
-      override def run() {
+      override def run(): Unit = {
         Thread.sleep(10000)
       }
     }

--- a/util-jvm/src/test/scala/com/twitter/jvm/JvmTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/JvmTest.scala
@@ -20,7 +20,7 @@ class JvmTest extends WordSpec with TestLogging {
           def compileThresh = None
         }
         def snapCounters = Map()
-        def setSnap(snap: Snapshot) {
+        def setSnap(snap: Snapshot): Unit = {
           currentSnap = snap
         }
 
@@ -28,7 +28,7 @@ class JvmTest extends WordSpec with TestLogging {
 
         def snap = currentSnap
 
-        def pushGc(gc: Gc) {
+        def pushGc(gc: Gc): Unit = {
           val gcs = snap.lastGcs filter (_.name != gc.name)
           setSnap(snap.copy(lastGcs = gc +: gcs))
         }

--- a/util-logging/src/main/scala/com/twitter/logging/FileHandler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/FileHandler.scala
@@ -147,13 +147,13 @@ class FileHandler(
     }
   }
 
-  def flush() {
+  def flush(): Unit = {
     synchronized {
       stream.flush()
     }
   }
 
-  def close() {
+  def close(): Unit = {
     synchronized {
       flush()
       try {
@@ -172,7 +172,7 @@ class FileHandler(
     new FileOutputStream(filename, append)
   }
 
-  private def openLog() {
+  private def openLog(): Unit = {
     synchronized {
       stream = openStream()
       openTime = Time.now.inMilliseconds
@@ -237,7 +237,7 @@ class FileHandler(
    * Delete files when "too many" have accumulated.
    * This duplicates logrotate's "rotate count" option.
    */
-  private def removeOldFiles() {
+  private def removeOldFiles(): Unit = {
     if (rotateCount >= 0) {
       // collect files which are not `filename`, but which share the prefix/suffix
       val prefixName = new File(filenamePrefix).getName
@@ -265,7 +265,7 @@ class FileHandler(
     removeOldFiles()
   }
 
-  def publish(record: javalog.LogRecord) {
+  def publish(record: javalog.LogRecord): Unit = {
     try {
       val formattedLine = getFormatter.format(record)
       val formattedBytes = formattedLine.getBytes(FileHandler.UTF8)
@@ -296,7 +296,7 @@ class FileHandler(
     }
   }
 
-  private def handleThrowable(e: Throwable) {
+  private def handleThrowable(e: Throwable): Unit = {
     System.err.println(Formatter.formatStackTrace(e, 30).mkString("\n"))
   }
 

--- a/util-logging/src/main/scala/com/twitter/logging/Handler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/Handler.scala
@@ -71,9 +71,9 @@ abstract class ProxyHandler(val handler: Handler)
 }
 
 object NullHandler extends Handler(BareFormatter, None) {
-  def publish(record: javalog.LogRecord) {}
-  def close() {}
-  def flush() {}
+  def publish(record: javalog.LogRecord): Unit = {}
+  def close(): Unit = {}
+  def flush(): Unit = {}
 
   // for java compatibility
   def get(): this.type = this

--- a/util-logging/src/main/scala/com/twitter/logging/LogRecord.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/LogRecord.scala
@@ -46,17 +46,17 @@ class LogRecord(level: javalog.Level, msg: String) extends javalog.LogRecord(lev
     sourceMethodName
   }
 
-  override def setSourceClassName(name: String) {
+  override def setSourceClassName(name: String): Unit = {
     inferred = true
     sourceClassName = name
   }
 
-  override def setSourceMethodName(name: String) {
+  override def setSourceMethodName(name: String): Unit = {
     inferred = true
     sourceMethodName = name
   }
 
-  private[this] def infer() {
+  private[this] def infer(): Unit = {
     // TODO: there is a small optimization we can do in jdk7 with new JavaLangAccess
     val stack = Thread.currentThread.getStackTrace()
 

--- a/util-logging/src/main/scala/com/twitter/logging/Logger.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/Logger.scala
@@ -131,7 +131,7 @@ class Logger protected (val name: String, private val wrapped: javalog.Logger) {
    * formatting is required.
    */
   @varargs
-  final def log(level: Level, thrown: Throwable, message: String, items: Any*) {
+  final def log(level: Level, thrown: Throwable, message: String, items: Any*): Unit = {
     val myLevel = getLevel
     if ((myLevel eq null) || (level.intValue >= myLevel.intValue)) {
 
@@ -448,7 +448,7 @@ object Logger extends Iterable[Logger] {
    * Reset all the loggers and register new loggers
    * @note Only one logger is permitted per namespace
    */
-  def configure(loggerFactories: List[() => Logger]) {
+  def configure(loggerFactories: List[() => Logger]): Unit = {
     loggerFactoryCache = loggerFactories
 
     clearHandlers()

--- a/util-logging/src/main/scala/com/twitter/logging/ScribeHandler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/ScribeHandler.scala
@@ -190,9 +190,9 @@ class ScribeHandler(
 
   def queueSize: Int = queue.size()
 
-  override def flush() {
+  override def flush(): Unit = {
 
-    def connect() {
+    def connect(): Unit = {
       if (!socket.isDefined) {
         if (Time.now.since(lastConnectAttempt) > connectBackoff) {
           try {
@@ -247,7 +247,7 @@ class ScribeHandler(
     }
 
     // TODO we should send any remaining messages before the app terminates
-    def sendBatch() {
+    def sendBatch(): Unit = {
       synchronized {
         connect()
         detectArchaicServer()
@@ -309,7 +309,7 @@ class ScribeHandler(
     }
 
     flusher.execute(new Runnable {
-      def run() { sendBatch() }
+      def run(): Unit = { sendBatch() }
     })
   }
 
@@ -344,7 +344,7 @@ class ScribeHandler(
     buffer
   }
 
-  private def closeSocket() {
+  private def closeSocket(): Unit = {
     synchronized {
       socket.foreach { s =>
         try {
@@ -357,7 +357,7 @@ class ScribeHandler(
     }
   }
 
-  override def close() {
+  override def close(): Unit = {
     stats.incrCloses()
     // TODO consider draining the flusher queue before returning
     // nothing stops a pending flush from opening a new socket
@@ -365,12 +365,12 @@ class ScribeHandler(
     flusher.shutdown()
   }
 
-  override def publish(record: javalog.LogRecord) {
+  override def publish(record: javalog.LogRecord): Unit = {
     if (record.getLoggerName == loggerName) return
     publish(getFormatter.format(record).getBytes("UTF-8"))
   }
 
-  def publish(record: Array[Byte]) {
+  def publish(record: Array[Byte]): Unit = {
     stats.incrPublished()
     if (!queue.offer(record)) stats.incrDroppedRecords()
     if (Time.now.since(_lastTransmission) >= bufferTime) flush()

--- a/util-logging/src/main/scala/com/twitter/logging/SyslogHandler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/SyslogHandler.scala
@@ -174,14 +174,14 @@ object SyslogFuture {
   private val executor = Executors.newSingleThreadExecutor(
     new NamedPoolThreadFactory("TWITTER-UTIL-SYSLOG", true /*daemon*/ )
   )
-  private val noop = new Runnable { def run() {} }
+  private val noop = new Runnable { def run(): Unit = {} }
 
   def apply(action: => Unit) =
     executor.submit(new Runnable {
-      def run() { action }
+      def run(): Unit = { action }
     })
 
-  def sync() {
+  def sync(): Unit = {
     val f = executor.submit(noop)
     f.get()
   }

--- a/util-logging/src/main/scala/com/twitter/logging/ThrottledHandler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/ThrottledHandler.scala
@@ -103,7 +103,7 @@ class ThrottledHandler(
       didExpire
     }
 
-    private[this] def publishSwallowed() {
+    private[this] def publishSwallowed(): Unit = {
       val throttledRecord = new javalog.LogRecord(
         level,
         "(swallowed %d repeating messages)".format(count - maxToDisplay)
@@ -117,14 +117,14 @@ class ThrottledHandler(
   private val throttleMap = new mutable.HashMap[String, Throttle]
 
   @deprecated("Use flushThrottled() instead", "5.3.13")
-  def reset() {
+  def reset(): Unit = {
     flushThrottled()
   }
 
   /**
    * Force printing any "swallowed" messages.
    */
-  def flushThrottled() {
+  def flushThrottled(): Unit = {
     synchronized {
       val now = Time.now
       throttleMap retain {
@@ -137,7 +137,7 @@ class ThrottledHandler(
    * Log a message, with sprintf formatting, at the desired level, and
    * attach an exception and stack trace.
    */
-  override def publish(record: javalog.LogRecord) {
+  override def publish(record: javalog.LogRecord): Unit = {
     val now = Time.now
     val last = lastFlushCheck.get
 
@@ -149,7 +149,7 @@ class ThrottledHandler(
       case r: LazyLogRecordUnformatted => r.preformatted
       case _ => record.getMessage
     }
-    @tailrec def tryPublish() {
+    @tailrec def tryPublish(): Unit = {
       val throttle = synchronized {
         throttleMap.getOrElseUpdate(
           key,

--- a/util-logging/src/main/scala/com/twitter/logging/config/LoggerConfig.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/config/LoggerConfig.scala
@@ -134,7 +134,7 @@ class SyslogFormatterConfig extends FormatterConfig {
    */
   var priority: Int = SyslogHandler.PRIORITY_USER
 
-  def serverName_=(name: String) { serverName = Some(name) }
+  def serverName_=(name: String): Unit = { serverName = Some(name) }
 
   override def apply() =
     new SyslogFormatter(

--- a/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
@@ -140,7 +140,7 @@ class FormatterTest extends WordSpec {
 
     "write stack traces" should {
       object ExceptionLooper {
-        def cycle(n: Int) {
+        def cycle(n: Int): Unit = {
           if (n == 0) {
             throw new Exception("Aie!")
           } else {
@@ -149,7 +149,7 @@ class FormatterTest extends WordSpec {
           }
         }
 
-        def cycle2(n: Int) {
+        def cycle2(n: Int): Unit = {
           try {
             cycle(n)
           } catch {

--- a/util-logging/src/test/scala/com/twitter/logging/LogRecordTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LogRecordTest.scala
@@ -43,7 +43,7 @@ class Foo
     extends LogRecordTestHelper({ r: JRecord =>
       r.getSourceClassName()
     }) {
-  def makingLogRecord() {
+  def makingLogRecord(): Unit = {
     logger.log(Level.INFO, "OK")
   }
 

--- a/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
@@ -52,7 +52,7 @@ class LoggerTest extends WordSpec with TempFolder with BeforeAndAfter {
    *
    * This is meant to be used in a `before` block.
    */
-  def traceLogger(level: Level) {
+  def traceLogger(level: Level): Unit = {
     traceLogger("", level)
   }
 
@@ -62,7 +62,7 @@ class LoggerTest extends WordSpec with TempFolder with BeforeAndAfter {
    *
    * This is meant to be used in a `before` block.
    */
-  def traceLogger(name: String, level: Level) {
+  def traceLogger(name: String, level: Level): Unit = {
     traceHandler.clear()
     val logger = Logger.get(name)
     logger.setLevel(level)

--- a/util-logging/src/test/scala/com/twitter/logging/QueueingHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/QueueingHandlerTest.scala
@@ -75,14 +75,14 @@ class QueueingHandlerTest extends WordSpec with Eventually with IntegrationPatie
     "publish, drop on overflow" in {
       val logger = freshLogger()
       val blockingHandler = new MockHandler {
-        override def publish(record: javalog.LogRecord) {
+        override def publish(record: javalog.LogRecord): Unit = {
           Thread.sleep(100000)
         }
       }
       @volatile var droppedCount = 0
 
       val queueHandler = new QueueingHandler(blockingHandler, 1) {
-        override protected def onOverflow(record: javalog.LogRecord) {
+        override protected def onOverflow(record: javalog.LogRecord): Unit = {
           droppedCount += 1
         }
       }
@@ -102,7 +102,7 @@ class QueueingHandlerTest extends WordSpec with Eventually with IntegrationPatie
       val logger = freshLogger()
       var wasFlushed = false
       val handler = new MockHandler {
-        override def flush() { wasFlushed = true }
+        override def flush(): Unit = { wasFlushed = true }
       }
       val queueHandler = new QueueingHandler(handler, 1)
       logger.addHandler(queueHandler)
@@ -117,7 +117,7 @@ class QueueingHandlerTest extends WordSpec with Eventually with IntegrationPatie
       val logger = freshLogger()
       var wasClosed = false
       val handler = new MockHandler {
-        override def close() { wasClosed = true }
+        override def close(): Unit = { wasClosed = true }
       }
       val queueHandler = new QueueingHandler(handler)
       logger.addHandler(queueHandler)
@@ -135,7 +135,7 @@ class QueueingHandlerTest extends WordSpec with Eventually with IntegrationPatie
       @volatile var mustError = true
       @volatile var didLog = false
       val handler = new MockHandler {
-        override def publish(record: javalog.LogRecord) {
+        override def publish(record: javalog.LogRecord): Unit = {
           if (mustError) {
             mustError = false
             throw new Exception("Unable to log for whatever reason.")

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/Gauge.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/Gauge.scala
@@ -5,5 +5,5 @@ package com.twitter.finagle.stats
  * computed health metric.
  */
 trait Gauge {
-  def remove()
+  def remove(): Unit
 }

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
@@ -44,7 +44,7 @@ class StatsReceiverTest extends FunSuite {
 
     class MemStat extends Stat {
       var values: Seq[Float] = ArrayBuffer.empty[Float]
-      def add(f: Float) { values = values :+ f }
+      def add(f: Float): Unit = { values = values :+ f }
     }
     val s1 = new MemStat
     val s2 = new MemStat

--- a/util-test/src/main/scala/com/twitter/logging/TestLogging.scala
+++ b/util-test/src/main/scala/com/twitter/logging/TestLogging.scala
@@ -48,7 +48,7 @@ trait TestLogging extends BeforeAndAfter { self: WordSpec =>
    *
    * This is meant to be used in a `before` block.
    */
-  def traceLogger(level: Level) {
+  def traceLogger(level: Level): Unit = {
     traceLogger("", level)
   }
 
@@ -58,7 +58,7 @@ trait TestLogging extends BeforeAndAfter { self: WordSpec =>
    *
    * This is meant to be used in a `before` block.
    */
-  def traceLogger(name: String, level: Level) {
+  def traceLogger(name: String, level: Level): Unit = {
     traceHandler.clear()
     val logger = Logger.get(name)
     logger.setLevel(level)

--- a/util-tunable/src/main/scala/com/twitter/util/tunable/linter/ConfigurationLinter.scala
+++ b/util-tunable/src/main/scala/com/twitter/util/tunable/linter/ConfigurationLinter.scala
@@ -7,7 +7,7 @@ import java.net.URL
 
 object ConfigurationLinter extends App {
 
-  def main() {
+  def main(): Unit = {
     var allSucceeded = true
 
     println("\nValidating TunableMap configuration files...")

--- a/util-zk/src/main/scala/com/twitter/zk/AsyncCallbackPromise.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/AsyncCallbackPromise.scala
@@ -13,7 +13,7 @@ import com.twitter.util.{Promise, Return, Throw}
 trait AsyncCallbackPromise[T] extends Promise[T] {
 
   /** Process result iff rc is OK; otherwise throw a KeeperException. */
-  protected def process(rc: Int, path: String)(result: => T) {
+  protected def process(rc: Int, path: String)(result: => T): Unit = {
     KeeperException.Code.get(rc) match {
       case KeeperException.Code.OK => updateIfEmpty(Return(result))
       case code => updateIfEmpty(Throw(KeeperException.create(code, path)))
@@ -22,13 +22,13 @@ trait AsyncCallbackPromise[T] extends Promise[T] {
 }
 
 class StringCallbackPromise extends AsyncCallbackPromise[String] with AsyncCallback.StringCallback {
-  def processResult(rc: Int, path: String, ctx: AnyRef, name: String) {
+  def processResult(rc: Int, path: String, ctx: AnyRef, name: String): Unit = {
     process(rc, path) { name }
   }
 }
 
 class UnitCallbackPromise extends AsyncCallbackPromise[Unit] with AsyncCallback.VoidCallback {
-  def processResult(rc: Int, path: String, ctx: AnyRef) {
+  def processResult(rc: Int, path: String, ctx: AnyRef): Unit = {
     process(rc, path) { Unit }
   }
 }
@@ -36,7 +36,7 @@ class UnitCallbackPromise extends AsyncCallbackPromise[Unit] with AsyncCallback.
 class ExistsCallbackPromise(znode: ZNode)
     extends AsyncCallbackPromise[ZNode.Exists]
     with AsyncCallback.StatCallback {
-  def processResult(rc: Int, path: String, ctx: AnyRef, stat: Stat) {
+  def processResult(rc: Int, path: String, ctx: AnyRef, stat: Stat): Unit = {
     process(rc, path) {
       znode(stat)
     }
@@ -46,7 +46,7 @@ class ExistsCallbackPromise(znode: ZNode)
 class ChildrenCallbackPromise(znode: ZNode)
     extends AsyncCallbackPromise[ZNode.Children]
     with AsyncCallback.Children2Callback {
-  def processResult(rc: Int, path: String, ctx: AnyRef, children: JList[String], stat: Stat) {
+  def processResult(rc: Int, path: String, ctx: AnyRef, children: JList[String], stat: Stat): Unit = {
     process(rc, path) {
       znode(stat, children.asScala.toSeq)
     }
@@ -56,7 +56,7 @@ class ChildrenCallbackPromise(znode: ZNode)
 class DataCallbackPromise(znode: ZNode)
     extends AsyncCallbackPromise[ZNode.Data]
     with AsyncCallback.DataCallback {
-  def processResult(rc: Int, path: String, ctx: AnyRef, bytes: Array[Byte], stat: Stat) {
+  def processResult(rc: Int, path: String, ctx: AnyRef, bytes: Array[Byte], stat: Stat): Unit = {
     process(rc, path) {
       znode(stat, bytes)
     }

--- a/util-zk/src/main/scala/com/twitter/zk/Connector.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/Connector.scala
@@ -37,7 +37,7 @@ trait Connector {
   }
 
   @tailrec
-  final def onSessionEvent(f: EventHandler) {
+  final def onSessionEvent(f: EventHandler): Unit = {
     val list = listeners.get()
     if (!listeners.compareAndSet(list, f :: list)) onSessionEvent(f)
   }

--- a/util-zk/src/main/scala/com/twitter/zk/Event.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/Event.scala
@@ -100,9 +100,9 @@ object NodeEvent {
 }
 
 class EventPromise extends Promise[WatchedEvent] with Watcher {
-  def process(event: WatchedEvent) { updateIfEmpty(Return(event)) }
+  def process(event: WatchedEvent): Unit = { updateIfEmpty(Return(event)) }
 }
 
 class EventBroker extends Broker[WatchedEvent] with Watcher {
-  def process(event: WatchedEvent) { send(event).sync() }
+  def process(event: WatchedEvent): Unit = { send(event).sync() }
 }

--- a/util-zk/src/main/scala/com/twitter/zk/NativeConnector.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/NativeConnector.scala
@@ -141,7 +141,7 @@ object NativeConnector {
      */
     val sessionEvents: Offer[StateEvent] = {
       val broker = new Broker[StateEvent]
-      def loop() {
+      def loop(): Unit = {
         sessionBroker.recv.sync()
           .map { StateEvent(_) }
           .respond {

--- a/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
@@ -213,14 +213,14 @@ trait ZNode {
     val broker = new Broker[ZNode.TreeUpdate]
 
     /** Pipe events from a subtree's monitor to this broker. */
-    def pipeSubTreeUpdates(next: Offer[ZNode.TreeUpdate]) {
+    def pipeSubTreeUpdates(next: Offer[ZNode.TreeUpdate]): Unit = {
       next.sync().flatMap(broker ! _).onSuccess { _ =>
         pipeSubTreeUpdates(next)
       }
     }
 
     /** Monitor a watch on this node. */
-    def monitorWatch(watch: Future[ZNode.Watch[ZNode.Children]], knownChildren: Set[ZNode]) {
+    def monitorWatch(watch: Future[ZNode.Watch[ZNode.Children]], knownChildren: Set[ZNode]): Unit = {
       log.debug("monitoring %s with %d known children", path, knownChildren.size)
       watch onFailure { e =>
         // An error occurred and there's not really anything we can do about it.

--- a/util-zk/src/main/scala/com/twitter/zk/ZOp.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZOp.scala
@@ -20,7 +20,7 @@ trait ZOp[T <: ZNode.Exists] {
   def monitor(): Offer[Try[T]] = {
     val broker = new Broker[Try[T]]
     // Set the watch, send the result to the broker, and repeat this when an event occurs
-    def setWatch() {
+    def setWatch(): Unit = {
       watch() onSuccess {
         case ZNode.Watch(result, update) =>
           broker ! result onSuccess { _ =>

--- a/util-zk/src/main/scala/com/twitter/zk/ZkClient.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZkClient.scala
@@ -32,7 +32,7 @@ trait ZkClient {
   def apply(): Future[ZooKeeper] = connector()
 
   /** Attach a listener to receive session events */
-  def onSessionEvent(f: PartialFunction[StateEvent, Unit]) {
+  def onSessionEvent(f: PartialFunction[StateEvent, Unit]): Unit = {
     connector.onSessionEvent(f)
   }
 

--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
@@ -49,7 +49,7 @@ class ZkAsyncSemaphore(zk: ZkClient, path: String, numPermits: Int, maxWaiters: 
   private[this] class ZkSemaphorePermit(node: ZNode) extends Permit {
     val zkPath = node.path
     val sequenceNumber = sequenceNumberOf(zkPath)
-    override def release() {
+    override def release(): Unit = {
       node.delete()
     }
   }

--- a/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
@@ -14,7 +14,7 @@ class ZNodeTest extends WordSpec with MockitoSugar {
     class ZNodeSpecHelper {
       val zk = mock[ZkClient]
     }
-    def pathTest(path: String, parent: String, name: String) {
+    def pathTest(path: String, parent: String, name: String): Unit = {
       val h = new ZNodeSpecHelper
       import h._
 

--- a/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
@@ -58,7 +58,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       data: Array[Byte] = "".getBytes,
       acls: Seq[ACL] = zkClient.acl,
       mode: CreateMode = zkClient.mode
-    )(wait: => Future[String]) {
+    )(wait: => Future[String]): Unit = {
       when(
         zk.create(
           meq(path),
@@ -78,7 +78,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def delete(path: String, version: Int)(wait: => Future[Unit]) {
+    def delete(path: String, version: Int)(wait: => Future[Unit]): Unit = {
       when(zk.delete(meq(path), meq(version), any[AsyncCallback.VoidCallback], meq(null))) thenAnswer answer[
         AsyncCallback.VoidCallback
       ](2) { cbValue =>
@@ -91,7 +91,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def exists(path: String)(stat: => Future[Stat]) {
+    def exists(path: String)(stat: => Future[Stat]): Unit = {
       when(
         zk.exists(
           meq(path),
@@ -109,7 +109,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def watch(path: String)(stat: => Future[Stat])(update: => Future[WatchedEvent]) {
+    def watch(path: String)(stat: => Future[Stat])(update: => Future[WatchedEvent]): Unit = {
       val watcher = ArgumentCaptor.forClass(classOf[Watcher])
       val cb = ArgumentCaptor.forClass(classOf[AsyncCallback.StatCallback])
       when(zk.exists(meq(path), watcher.capture(), cb.capture(), meq(null))) thenAnswer answer[
@@ -127,7 +127,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def getChildren(path: String)(children: => Future[ZNode.Children]) {
+    def getChildren(path: String)(children: => Future[ZNode.Children]): Unit = {
       val cb = ArgumentCaptor.forClass(classOf[AsyncCallback.Children2Callback])
       when(zk.getChildren(meq(path), meq(false), any[AsyncCallback.Children2Callback], meq(null))) thenAnswer answer[
         AsyncCallback.Children2Callback
@@ -149,7 +149,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
 
     def watchChildren(
       path: String
-    )(children: => Future[ZNode.Children])(update: => Future[WatchedEvent]) {
+    )(children: => Future[ZNode.Children])(update: => Future[WatchedEvent]): Unit = {
       val w = ArgumentCaptor.forClass(classOf[Watcher])
       val cb = ArgumentCaptor.forClass(classOf[AsyncCallback.Children2Callback])
       when(zk.getChildren(meq(path), w.capture(), cb.capture(), meq(null))) thenAnswer answer[
@@ -168,7 +168,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def getData(path: String)(result: => Future[ZNode.Data]) {
+    def getData(path: String)(result: => Future[ZNode.Data]): Unit = {
       when(zk.getData(meq(path), meq(false), any[AsyncCallback.DataCallback], meq(null))) thenAnswer answer[
         AsyncCallback.DataCallback
       ](2) { cbValue =>
@@ -181,7 +181,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def watchData(path: String)(result: => Future[ZNode.Data])(update: => Future[WatchedEvent]) {
+    def watchData(path: String)(result: => Future[ZNode.Data])(update: => Future[WatchedEvent]): Unit = {
       val w = ArgumentCaptor.forClass(classOf[Watcher])
       val cb = ArgumentCaptor.forClass(classOf[AsyncCallback.DataCallback])
       when(zk.getData(meq(path), w.capture(), cb.capture(), meq(null))) thenAnswer answer[
@@ -199,7 +199,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def setData(path: String, data: Array[Byte], version: Int)(waiting: => Future[Stat]) {
+    def setData(path: String, data: Array[Byte], version: Int)(waiting: => Future[Stat]): Unit = {
       when(
         zk.setData(meq(path), meq(data), meq(version), any[AsyncCallback.StatCallback], meq(null))
       ) thenAnswer answer[AsyncCallback.StatCallback](3) { cbValue =>
@@ -212,7 +212,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       }
     }
 
-    def sync(path: String)(wait: Future[Unit]) {
+    def sync(path: String)(wait: Future[Unit]): Unit = {
       val cb = ArgumentCaptor.forClass(classOf[AsyncCallback.VoidCallback])
       when(zk.sync(meq(path), any[AsyncCallback.VoidCallback], meq(null))) thenAnswer answer[
         AsyncCallback.VoidCallback
@@ -539,7 +539,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
       "monitor" should {
         class MonitorHelper extends ExistHelper {
           val deleted = NodeEvent.Deleted(znode.path)
-          def expectZNodes(n: Int) {
+          def expectZNodes(n: Int): Unit = {
             val results = 0 until n map { _ =>
               ZNode.Exists(znode, new Stat)
             }
@@ -805,7 +805,7 @@ class ZkClientTest extends WordSpec with MockitoSugar {
         z.path -> ZNode.TreeUpdate(z, z.children.toSet -- prior, prior -- z.children.toSet)
       }.toMap
 
-      def okUpdates(event: String => WatchedEvent) {
+      def okUpdates(event: String => WatchedEvent): Unit = {
         // Create promises for each node in the tree -- satisfying a promise will fire a
         // ChildrenChanged event for its associated node.
         val updatePromises = treeChildren.map { _.path -> new Promise[WatchedEvent] }.toMap


### PR DESCRIPTION
### Problem

procedure syntax is deprecated since Scala 2.13 https://github.com/scala/scala/commit/b5799032760d5aaab5739a41816fb74653bcc82c

### Solution

rewrite by scalafix (version 0.6.0-M7)
https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax

`scalafix --rules ProcedureSyntax`

### Result

There is no semantic changes. source and binary compatible.