### PR TITLE
use Gen.delay instead of Gen.wrap

### DIFF
--- a/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
@@ -12,7 +12,7 @@ class DelegatingStatsReceiverTest extends FunSuite with GeneratorDrivenPropertyC
   class Ctx {
     var leafCounter = 0
 
-    private[this] val inMemoryStatsReceiver: Gen[StatsReceiver] = Gen.wrap {
+    private[this] val inMemoryStatsReceiver: Gen[StatsReceiver] = Gen.delay {
       leafCounter += 1
       Gen.const(new InMemoryStatsReceiver())
     }
@@ -67,7 +67,7 @@ class DelegatingStatsReceiverTest extends FunSuite with GeneratorDrivenPropertyC
       Gen.oneOf(seq).flatMap(identity)
     }
 
-    implicit val impl = Arbitrary(Gen.wrap(statsReceiverTopology(0)))
+    implicit val impl = Arbitrary(Gen.delay(statsReceiverTopology(0)))
   }
 
   test("DelegatingStatsReceiver.all collects effectively across many StatsReceivers") {


### PR DESCRIPTION
### Problem

`org.scalacheck.Gen.wrap` is deprecated since scalacheck 1.13.0. removed scalacheck 1.14.0

### Solution

use `Gen.delay`

### Result

fix https://github.com/twitter/util/issues/214.
There is no substantial changes because `Gen.wrap` call `Gen.delay`.
https://github.com/rickynils/scalacheck/blob/1.13.4/src/main/scala/org/scalacheck/Gen.scala#L446
