### PR TITLE
make catch exception handling less restrictive in util-jvm

### DIFF
--- a/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
@@ -261,7 +261,9 @@ object Jvm {
   private lazy val _jvm =
     try new Hotspot
     catch {
-      case NonFatal(_) => NilJvm
+      case _: Throwable =>
+        log.log(Level.WARNING, "failed to create Hotspot JVM interface, using NilJvm instead")
+        NilJvm
     }
 
   private val log = Logger.getLogger(getClass.getName)

--- a/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
@@ -262,7 +262,7 @@ object Jvm {
     try new Hotspot
     catch {
       case NonFatal(_) | _: UnsatisfiedLinkError =>
-        log.log(Level.WARNING, "failed to create Hotspot JVM interface, using NilJvm instead")
+        log.warning("failed to create Hotspot JVM interface, using NilJvm instead")
         NilJvm
     }
 

--- a/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
@@ -261,7 +261,7 @@ object Jvm {
   private lazy val _jvm =
     try new Hotspot
     catch {
-      case _: Throwable =>
+      case NonFatal(_) | _: UnsatisfiedLinkError =>
         log.log(Level.WARNING, "failed to create Hotspot JVM interface, using NilJvm instead")
         NilJvm
     }


### PR DESCRIPTION
Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>

Problem

When using the twitter `util-jvm` with a non-Hotpost JVM, the library tries to create an interface that applies reflection on Hotspot specific classes. This causes a Finagle application to crash with the stacktrace outlined in #213. 

Solution
The previous code catches `NonFatal` exceptions and returns a `NilJvm` in that scenario. This PR changes this behavior so that a `NilJvm` is returned on `NonFatal` and `UnsatisfiedLinkedError` exceptions when a new `Hotspot` instance creation is attempted.
 
Testing this kind of behavior is virtually impossible in a unit test. Tests were done using docker where a non-Hotspot JVM was used in conjunction with a Finagle application (Linkerd). The application ran successfully without crashing.

fixes #213 