### PR TITLE
Fix typo in withCurrentTimeFrozen

### DIFF
--- a/doc/src/sphinx/util-cookbook/basics.rst
+++ b/doc/src/sphinx/util-cookbook/basics.rst
@@ -138,7 +138,7 @@ Scala:
     import com.twitter.conversions.time._
     import com.twitter.util.{Future, MockTimer, Time}
 
-    Time.withWithCurrentTimeFrozen { timeControl =>
+    Time.withCurrentTimeFrozen { timeControl =>
       val timer = new MockTimer()
       // schedule some work for later
       val f: Future[String] = timer.doLater(1.millisecond) {


### PR DESCRIPTION
Problem

The snippet listed in https://twitter.github.io/util/guide/util-cookbook/basics.html#controlling-timers contains a typo in the `Time.withCurrentTimeFrozen` method.

Solution

Fix the typo
