### PR TITLE
address deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ val scalacheckLib = "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 val slf4jLib = "org.slf4j" % "slf4j-api" % slf4jVersion
 
 val defaultProjectSettings = Seq(
-  scalaVersion := "2.12.4",
-  crossScalaVersions := Seq("2.11.11", "2.12.4")
+  scalaVersion := "2.12.6",
+  crossScalaVersions := Seq("2.11.11", "2.12.6")
 )
 
 val baseSettings = Seq(
@@ -42,9 +42,9 @@ val baseSettings = Seq(
     "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
 
   scalacOptions := Seq(
-    // Note: Add -deprecation when deprecated methods are removed
     "-target:jvm-1.8",
     "-unchecked",
+    "-deprecation",
     "-feature",
     "-encoding", "utf8",
     // Needs -missing-interpolator due to https://issues.scala-lang.org/browse/SI-8761

--- a/util-cache/src/main/scala/com/twitter/cache/Refresh.scala
+++ b/util-cache/src/main/scala/com/twitter/cache/Refresh.scala
@@ -65,6 +65,6 @@ object Refresh {
         }
     }
     // Return result, which is a no-arg function that returns a future
-    result
+    result _
   }
 }

--- a/util-collection/src/main/scala/com/twitter/util/LruMap.scala
+++ b/util-collection/src/main/scala/com/twitter/util/LruMap.scala
@@ -3,7 +3,7 @@ package com.twitter.util
 import java.{util => ju}
 import java.util.LinkedHashMap
 import scala.collection.JavaConverters._
-import scala.collection.mutable.{Map, MapLike, SynchronizedMap}
+import scala.collection.mutable.{Map, MapLike}
 
 /**
  * A wrapper trait for java.util.Map implementations to make them behave as scala Maps.
@@ -64,7 +64,32 @@ class LruMap[K, V](val maxSize: Int, val underlying: ju.Map[K, V])
  */
 class SynchronizedLruMap[K, V](maxSize: Int, underlying: ju.Map[K, V])
     extends LruMap[K, V](maxSize, ju.Collections.synchronizedMap(underlying))
-    with SynchronizedMap[K, V] {
+    {
+  override def get(key: K): Option[V] = synchronized { super.get(key) }
+  override def iterator: Iterator[(K, V)] = synchronized { super.iterator }
+  override def += (kv: (K, V)): this.type = synchronized[this.type] { super.+=(kv) }
+  override def -= (key: K): this.type = synchronized[this.type] { super.-=(key) }
+
+  override def size: Int = synchronized { super.size }
+  override def put(key: K, value: V): Option[V] = synchronized { super.put(key, value) }
+  override def update(key: K, value: V): Unit = synchronized { super.update(key, value) }
+  override def remove(key: K): Option[V] = synchronized { super.remove(key) }
+  override def clear(): Unit = synchronized { super.clear() }
+  override def getOrElseUpdate(key: K, default: => V): V = synchronized { super.getOrElseUpdate(key, default) }
+  override def transform(f: (K, V) => V): this.type = synchronized[this.type] { super.transform(f) }
+  override def retain(p: (K, V) => Boolean): this.type = synchronized[this.type] { super.retain(p) }
+  override def values: scala.collection.Iterable[V] = synchronized { super.values }
+  override def valuesIterator: Iterator[V] = synchronized { super.valuesIterator }
+  override def clone(): Self = synchronized { super.clone() }
+  override def foreach[U](f: ((K, V)) => U) = synchronized { super.foreach(f) }
+  override def apply(key: K): V = synchronized { super.apply(key) }
+  override def keySet: scala.collection.Set[K] = synchronized { super.keySet }
+  override def keys: scala.collection.Iterable[K] = synchronized { super.keys }
+  override def keysIterator: Iterator[K] = synchronized { super.keysIterator }
+  override def isEmpty: Boolean = synchronized { super.isEmpty }
+  override def contains(key: K): Boolean = synchronized {super.contains(key) }
+  override def isDefinedAt(key: K) = synchronized { super.isDefinedAt(key) }
   override def empty: SynchronizedLruMap[K, V] = new SynchronizedLruMap[K, V](maxSize)
+  //!!! todo: also add all other methods
   def this(maxSize: Int) = this(maxSize, LruMap.makeUnderlying(maxSize))
 }

--- a/util-core/src/main/java/com/twitter/concurrent/Offers.java
+++ b/util-core/src/main/java/com/twitter/concurrent/Offers.java
@@ -4,7 +4,7 @@ import com.twitter.util.Duration;
 import com.twitter.util.Function0;
 import com.twitter.util.Future;
 import com.twitter.util.Timer;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.runtime.BoxedUnit;
 
 import java.util.ArrayList;
@@ -60,7 +60,7 @@ public final class Offers {
    * @see Offer$#choose(scala.collection.Seq)
    */
   public static <T> Offer<T> choose(Collection<Offer<T>> offers) {
-    return Offer$.MODULE$.choose(JavaConversions.asScalaBuffer(new ArrayList<Offer<T>>(offers)));
+    return Offer$.MODULE$.choose(JavaConverters.asScalaBuffer(new ArrayList<Offer<T>>(offers)));
   }
 
   /**

--- a/util-core/src/main/java/com/twitter/concurrent/Spools.java
+++ b/util-core/src/main/java/com/twitter/concurrent/Spools.java
@@ -1,6 +1,6 @@
 package com.twitter.concurrent;
 
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import java.util.ArrayList;
@@ -22,7 +22,7 @@ public final class Spools {
    * Creates a new `Spool` of given `elems`.
    */
   public static <T> Spool<T> newSpool(Collection<T> elems) {
-    Seq<T> seq = JavaConversions.asScalaBuffer(new ArrayList<T>(elems)).toSeq();
+    Seq<T> seq = JavaConverters.asScalaBuffer(new ArrayList<T>(elems)).toSeq();
     return new Spool.ToSpool<T>(seq).toSpool();
   }
 

--- a/util-core/src/main/java/com/twitter/util/Closables.java
+++ b/util-core/src/main/java/com/twitter/util/Closables.java
@@ -1,6 +1,6 @@
 package com.twitter.util;
 
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.runtime.BoxedUnit;
 
 import java.util.Arrays;
@@ -44,7 +44,7 @@ public final class Closables {
    */
   public static Closable all(Closable... closables) {
     return Closable$.MODULE$.all(
-      JavaConversions.asScalaBuffer(Arrays.asList(closables))
+      JavaConverters.asScalaBuffer(Arrays.asList(closables))
     );
   }
 
@@ -53,7 +53,7 @@ public final class Closables {
    */
   public static Closable sequence(Closable... closables) {
     return Closable$.MODULE$.sequence(
-      JavaConversions.asScalaBuffer(Arrays.asList(closables))
+      JavaConverters.asScalaBuffer(Arrays.asList(closables))
     );
   }
 

--- a/util-core/src/main/java/com/twitter/util/javainterop/Scala.java
+++ b/util-core/src/main/java/com/twitter/util/javainterop/Scala.java
@@ -3,14 +3,14 @@ package com.twitter.util.javainterop;
 import scala.Option;
 import scala.Tuple2;
 
-import static scala.collection.JavaConversions.asScalaBuffer;
-import static scala.collection.JavaConversions.asScalaSet;
+import static scala.collection.JavaConverters.asScalaBuffer;
+import static scala.collection.JavaConverters.asScalaSet;
 
 /**
  * A collection of conversions from Java collections to their immutable
  * Scala variants.
  *
- * See scala.collection.JavaConversions if you do not need immutable
+ * See scala.collection.JavaConverters if you do not need immutable
  * collections.
  */
 public final class Scala {
@@ -20,7 +20,7 @@ public final class Scala {
   /**
    * Converts a {@link java.util.List} to an immutable Scala Seq.
    *
-   * See scala.collection.JavaConversions.asScalaBuffer if you do
+   * See scala.collection.JavaConverters.asScalaBuffer if you do
    * not need the returned Seq to be immutable.
    *
    * @return an empty Seq if the input is null.
@@ -39,7 +39,7 @@ public final class Scala {
   /**
    * Converts a {@link java.util.Set} to an immutable Scala Set.
    *
-   * See scala.collection.JavaConversions.asScalaSet if you do
+   * See scala.collection.JavaConverters.asScalaSet if you do
    * not need the returned Set to be immutable.
    *
    * @return an empty Set if the input is null.
@@ -58,7 +58,7 @@ public final class Scala {
   /**
    * Converts a {@link java.util.Map} to an immutable Scala Map.
    *
-   * See scala.collection.JavaConversions.asScalaMap if you do
+   * See scala.collection.JavaConverters.asScalaMap if you do
    * not need the returned Map to be immutable.
    *
    * @return an empty Map if the input is null.

--- a/util-core/src/main/scala/com/twitter/util/Pool.scala
+++ b/util-core/src/main/scala/com/twitter/util/Pool.scala
@@ -41,7 +41,7 @@ class SimplePool[A](items: mutable.Queue[Future[A]]) extends Pool[A] {
 }
 
 abstract class FactoryPool[A](numItems: Int) extends Pool[A] {
-  private val healthyQueue = new HealthyQueue[A](makeItem, numItems, isHealthy)
+  private val healthyQueue = new HealthyQueue[A](makeItem _, numItems, isHealthy)
   private val simplePool = new SimplePool[A](healthyQueue)
 
   def reserve(): Future[A] = simplePool.reserve()

--- a/util-core/src/test/java/com/twitter/concurrent/SpoolCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/concurrent/SpoolCompilationTest.java
@@ -4,7 +4,7 @@ import com.twitter.util.Await;
 import com.twitter.util.Future;
 import org.junit.Assert;
 import org.junit.Test;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,9 +55,9 @@ public class SpoolCompilationTest {
     Spool<String> abNothing = ab.concat(Spools.<String>newEmptySpool());
     Spool<String> abc = Await.result(ab.concat(Future.value(c)));
 
-    Collection<String> listA = JavaConversions.seqAsJavaList(Await.result(ab.toSeq()));
-    Collection<String> listB = JavaConversions.seqAsJavaList(Await.result(abNothing.toSeq()));
-    Collection<String> listC = JavaConversions.seqAsJavaList(Await.result(abc.toSeq()));
+    Collection<String> listA = JavaConverters.seqAsJavaList(Await.result(ab.toSeq()));
+    Collection<String> listB = JavaConverters.seqAsJavaList(Await.result(abNothing.toSeq()));
+    Collection<String> listC = JavaConverters.seqAsJavaList(Await.result(abc.toSeq()));
 
     Assert.assertArrayEquals(new String[] { "a", "b"}, listA.toArray());
     Assert.assertArrayEquals(new String[] { "a", "b"}, listB.toArray());

--- a/util-core/src/test/java/com/twitter/io/BufCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/io/BufCompilationTest.java
@@ -3,7 +3,7 @@ package com.twitter.io;
 import org.junit.Assert;
 import org.junit.Test;
 import scala.Option;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -55,7 +55,7 @@ public class BufCompilationTest {
     Buf abc = Bufs.utf8Buf("abc");
     Buf def = Bufs.utf8Buf("def");
     Buf merged = Buf.apply(
-      JavaConversions.asScalaBuffer(Arrays.asList(empty, abc, def)));
+      JavaConverters.asScalaBuffer(Arrays.asList(empty, abc, def)));
   }
 
   @Test

--- a/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
@@ -276,12 +276,13 @@ class LoggerTest extends WordSpec with TempFolder with BeforeAndAfter {
       }
 
       "file handler" in {
+        val separator = java.io.File.pathSeparator
         withTempFolder {
           val log: Logger = LoggerFactory(
             node = "com.twitter",
             level = Some(Level.DEBUG),
             handlers = FileHandler(
-              filename = folderName + "/test.log",
+              filename = folderName + separator + "test.log",
               rollPolicy = Policy.Never,
               append = false,
               level = Some(Level.INFO),
@@ -296,7 +297,8 @@ class LoggerTest extends WordSpec with TempFolder with BeforeAndAfter {
           assert(log.getLevel == Level.DEBUG)
           assert(log.getHandlers().length == 1)
           val handler = log.getHandlers()(0).asInstanceOf[FileHandler]
-          assert(handler.filename == folderName + "/test.log")
+          val fileName = folderName + separator + "test.log"
+          assert(handler.filename == fileName)
           assert(handler.append == false)
           assert(handler.getLevel == Level.INFO)
           val formatter = handler.formatter

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
@@ -231,7 +231,7 @@ class InMemoryStatsReceiverTest extends FunSuite with Eventually with Integratio
 
       inMemoryStatsReceiver.print(ps, includeHeaders = true)
       val content = new String(baos.toByteArray, StandardCharsets.UTF_8)
-      val parts = content.split('\n')
+      val parts = content.filterNot(_ == '\r').split('\n')
 
       assert(parts.length == 17)
       assert(parts(0) == "Counters:")
@@ -294,7 +294,7 @@ class InMemoryStatsReceiverTest extends FunSuite with Eventually with Integratio
 
       inMemoryStatsReceiver.print(ps, includeHeaders = true)
       val content = new String(baos.toByteArray, StandardCharsets.UTF_8)
-      val parts = content.split('\n')
+      val parts = content.filterNot(_ == '\r').split('\n')
 
       assert(parts.length == 12)
       assert(parts(0) == "Counters:")

--- a/util-zk/src/main/scala/com/twitter/zk/Event.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/Event.scala
@@ -54,19 +54,17 @@ object StateEvent {
   }
 
   def apply(w: WatchedEvent): StateEvent = {
-    w.getState match {
+    val state = w.getState
+    state match {
       case KeeperState.AuthFailed => AuthFailed
       case KeeperState.SyncConnected => Connected
       case KeeperState.Disconnected => Disconnected
       case KeeperState.Expired => Expired
       case KeeperState.ConnectedReadOnly => ConnectedReadOnly
       case KeeperState.SaslAuthenticated => SaslAuthenticated
-      case KeeperState.Unknown =>
-        throw new IllegalArgumentException("Can't convert deprecated state to StateEvent: Unknown")
-      case KeeperState.NoSyncConnected =>
-        throw new IllegalArgumentException(
-          "Can't convert deprecated state to StateEvent: NoSyncConnected"
-        )
+      case _ => throw new IllegalArgumentException(s"Can't convert deprecated state to StateEvent: $state")
+      //NoSyncConnected and Unknown are depricated in zk 3.x, and should be
+      //expected to be removed in zk 4.x
     }
   }
 }


### PR DESCRIPTION
Enables and heeds deprecation warnings

Also make some tests platform-independent

Problem

there were deprecation warnings, and tests that failed on Windows

Solution

Remove deprecations

Result

The build will be deprecation-clean, aiding a possible 2.13 migration.
