### PR TITLE
tweak sources to compile on JDK 9

### DIFF
--- a/util-core/src/main/scala/com/twitter/io/Buf.scala
+++ b/util-core/src/main/scala/com/twitter/io/Buf.scala
@@ -870,9 +870,9 @@ object Buf {
       else if (isSliceIdentity(from, until)) this
       else {
         val dup = underlying.duplicate()
-        val limit = dup.position + math.min(until, length)
-        if (dup.limit > limit) dup.limit(limit)
-        dup.position(dup.position + from)
+        val limit = dup.position() + math.min(until, length)
+        if (dup.limit() > limit) dup.limit(limit)
+        dup.position(dup.position() + from)
         new ByteBuffer(dup)
       }
     }
@@ -886,7 +886,7 @@ object Buf {
     protected def unsafeByteArrayBuf: Option[Buf.ByteArray] =
       if (underlying.hasArray) {
         val array = underlying.array
-        val begin = underlying.arrayOffset + underlying.position
+        val begin = underlying.arrayOffset + underlying.position()
         val end = begin + underlying.remaining
         Some(new ByteArray(array, begin, end))
       } else None

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -763,7 +763,7 @@ class BufTest
     val bb0 = java.nio.ByteBuffer.wrap(bytes)
     val Buf.ByteBuffer.Shared(bb1) = Buf.ByteBuffer.Owned(bb0)
     bb1.position(3)
-    assert(bb0.position == 0)
+    assert(bb0.position() == 0)
   }
 
   test("Buf.ByteBuffer.Direct.unapply is unsafe") {
@@ -780,7 +780,7 @@ class BufTest
     val Buf.ByteBuffer(bb1) = Buf.ByteBuffer.Owned(bb0)
     assert(bb1.isReadOnly)
     bb1.position(3)
-    assert(bb0.position == 0)
+    assert(bb0.position() == 0)
   }
 
   test("ByteArray.coerce(ByteArray)") {


### PR DESCRIPTION
fixing compilation errors such as:

[error] /Users/tisue/twitter-util/util-core/src/main/scala/com/twitter/io/Buf.scala:873:25: ambiguous reference to overloaded definition,
[error] both method position in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method position in class Buffer of type ()Int
[error] match expected type ?
[error]         val limit = dup.position + math.min(until, length)
[error]                         ^

this came up in the Scala 2.12 community build