### PR TITLE
jvm: Use newer jdk management api when the old one is not available

### DIFF
--- a/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
@@ -9,6 +9,7 @@ import javax.management.openmbean.CompositeDataSupport
 import javax.management.{ObjectName, RuntimeMBeanException}
 import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
+import scala.util.control.NonFatal
 
 class Hotspot extends Jvm {
   private[this] val epoch =
@@ -32,7 +33,7 @@ class Hotspot extends Jvm {
       // jdk5/6 have jvm field in ManagementFactory class
       Class.forName("sun.management.ManagementFactory").getDeclaredField("jvm")
     } catch {
-      case _: Throwable =>
+      case NonFatal(_) =>
         // jdk7 moves jvm field to ManagementFactoryHelper class
         Class.forName("sun.management.ManagementFactoryHelper").getDeclaredField("jvm")
     }

--- a/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
@@ -32,7 +32,7 @@ class Hotspot extends Jvm {
       // jdk5/6 have jvm field in ManagementFactory class
       Class.forName("sun.management.ManagementFactory").getDeclaredField("jvm")
     } catch {
-      case _: NoSuchFieldException =>
+      case _: Throwable =>
         // jdk7 moves jvm field to ManagementFactoryHelper class
         Class.forName("sun.management.ManagementFactoryHelper").getDeclaredField("jvm")
     }


### PR DESCRIPTION
Problem

Newer jdks do not expose `sun.management.ManagementFactory`. The
code to branch between `sun.management.ManagementFactoryHelper` for
jdk7 and `sun.management.ManagementFactory` for earlier jdks only
caught `NoSuchFieldException`. This lead to the `NilJvm` being used
on newer jdks that do not expose `sun.management.ManagementFactory`.

Solution

Catch `Throwable` as is done elsewhere in the same codebase and
switch to the `sun.management.ManagementFactory`

Result

The Hotspot class can be instantiated for newer jdks.
