### PR TITLE
refactor: replace filter.size with more concise count

### DIFF
--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
@@ -267,7 +267,7 @@ class ZkAsyncSemaphore(
       val (numPermitsInMax, numBelieversOfMax) = permitsToBelievers.maxBy {
         case (_, believers) => believers
       }
-      val cardinalityOfMax = permitsToBelievers.values.filter({ _ == numBelieversOfMax }).size
+      val cardinalityOfMax = permitsToBelievers.values.count({ _ == numBelieversOfMax })
 
       if (cardinalityOfMax == 1) {
         // Consensus


### PR DESCRIPTION
refactors to use the simpler `count` function instead of `filter(...).size`