### PR TITLE
`GlobalFlag.getAll()` fails to validate flags defined within a package object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@ lib_managed/
 .DS_Store
 .ensime
 .ivyjars
-sbt
 out/
 sbt-launch.jar

--- a/util-app/src/main/scala/com/twitter/app/GlobalFlag.scala
+++ b/util-app/src/main/scala/com/twitter/app/GlobalFlag.scala
@@ -116,31 +116,35 @@ abstract class GlobalFlag[T] private[app](
 
 object GlobalFlag {
 
-  private[app] def get(className: String): Option[Flag[_]] = {
-    def tryMethod(cls: Class[_], methodName: String): Option[Flag[_]] = {
-      val m = cls.getMethod(methodName)
-      val isValid = Modifier.isStatic(m.getModifiers) && m.getReturnType == classOf[Flag[_]] && m.getParameterCount == 0
-      if (isValid) Some(m.invoke(null).asInstanceOf[Flag[_]]) else None
-    }
-
-    def tryModuleField(cls: Class[_]): Option[Flag[_]] = {
-      val f = cls.getField("MODULE$")
-      val isValid = Modifier.isStatic(f.getModifiers) && classOf[Flag[_]].isAssignableFrom(f.getType)
-      if (isValid) Some(f.get(null).asInstanceOf[Flag[_]]) else None
-    }
-
-    try {
-      val cls = Class.forName(if (!className.endsWith("$")) className + "$" else className)
-      tryModuleField(cls).orElse {
-        // fallback for GlobalFlags declared in Java
-        tryMethod(cls, "globalFlagInstance")
+  private[app] def get(flagName: String): Option[Flag[_]] = {
+    def tryMethod(className: String, methodName: String): Option[Flag[_]] =
+      try {
+        val cls = Class.forName(className)
+        val m = cls.getMethod(methodName)
+        val isValid = Modifier.isStatic(m.getModifiers) &&
+          m.getReturnType == classOf[Flag[_]] &&
+          m.getParameterCount == 0
+        if (isValid) Some(m.invoke(null).asInstanceOf[Flag[_]]) else None
+      } catch {
+        case _: ClassNotFoundException | _: NoSuchMethodException | _: IllegalArgumentException =>
+          None
       }
-    } catch {
-      case _: ClassNotFoundException |
-           _: NoSuchFieldException |
-           _: NoSuchMethodException |
-           _: IllegalArgumentException =>
-        None
+
+    def tryModuleField(className: String): Option[Flag[_]] =
+      try {
+        val cls = Class.forName(className)
+        val f = cls.getField("MODULE$")
+        val isValid = Modifier.isStatic(f.getModifiers) && classOf[Flag[_]].isAssignableFrom(f.getType)
+        if (isValid) Some(f.get(null).asInstanceOf[Flag[_]]) else None
+      } catch {
+        case _: ClassNotFoundException | _: NoSuchFieldException | _: IllegalArgumentException =>
+          None
+      }
+
+    val className = if (!flagName.endsWith("$")) flagName + "$" else flagName
+    tryModuleField(className).orElse {
+      // fallback for GlobalFlags declared in Java
+      tryMethod(className, "globalFlagInstance")
     }
   }
 

--- a/util-app/src/main/scala/com/twitter/app/GlobalFlag.scala
+++ b/util-app/src/main/scala/com/twitter/app/GlobalFlag.scala
@@ -5,51 +5,51 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 /**
-  * Subclasses of GlobalFlag (that are defined in libraries) are "global" in the
-  * sense that they are accessible by any application that depends on that library.
-  * Regardless of where in a library a GlobalFlag is defined, a value for it can
-  * be passed as a command-line flag by any binary that includes the library.
-  * The set of defined GlobalFlags can be enumerated (via `GlobalFlag.getAll)` by
-  * the application.
-  *
-  * A [[GlobalFlag]] must be declared as an `object` (see below for Java):
-  * {{{
-  * import com.twitter.app.GlobalFlag
-  *
-  * object myFlag extends GlobalFlag[String]("default value", "this is my global flag")
-  * }}}
-  *
-  * All such global flag declarations in a given classpath are visible to and
-  * used by [[com.twitter.app.App]].
-  *
-  * A flag's name (as set on the command line) is its fully-qualified classname.
-  * For example, the flag
-  *
-  * {{{
-  * package com.twitter.server
-  *
-  * import com.twitter.app.GlobalFlag
-  *
-  * object port extends GlobalFlag[Int](8080, "the TCP port to which we bind")
-  * }}}
-  *
-  * is settable by the command-line flag `-com.twitter.server.port=8080`.
-  *
-  * Global flags may also be set by Java system properties with keys
-  * named in the same way. However, values supplied by flags override
-  * those supplied by system properties.
-  *
-  * @define java_declaration
-  *
-  * If you'd like to declare a new [[GlobalFlag]] in Java, see [[JavaGlobalFlag]].
-  */
+ * Subclasses of GlobalFlag (that are defined in libraries) are "global" in the
+ * sense that they are accessible by any application that depends on that library.
+ * Regardless of where in a library a GlobalFlag is defined, a value for it can
+ * be passed as a command-line flag by any binary that includes the library.
+ * The set of defined GlobalFlags can be enumerated (via `GlobalFlag.getAll)` by
+ * the application.
+ *
+ * A [[GlobalFlag]] must be declared as an `object` (see below for Java):
+ * {{{
+ * import com.twitter.app.GlobalFlag
+ *
+ * object myFlag extends GlobalFlag[String]("default value", "this is my global flag")
+ * }}}
+ *
+ * All such global flag declarations in a given classpath are visible to and
+ * used by [[com.twitter.app.App]].
+ *
+ * A flag's name (as set on the command line) is its fully-qualified classname.
+ * For example, the flag
+ *
+ * {{{
+ * package com.twitter.server
+ *
+ * import com.twitter.app.GlobalFlag
+ *
+ * object port extends GlobalFlag[Int](8080, "the TCP port to which we bind")
+ * }}}
+ *
+ * is settable by the command-line flag `-com.twitter.server.port=8080`.
+ *
+ * Global flags may also be set by Java system properties with keys
+ * named in the same way. However, values supplied by flags override
+ * those supplied by system properties.
+ *
+ * @define java_declaration
+ *
+ * If you'd like to declare a new [[GlobalFlag]] in Java, see [[JavaGlobalFlag]].
+ */
 @GlobalFlagVisible
-abstract class GlobalFlag[T] private[app](
-                                           defaultOrUsage: Either[() => T, String],
-                                           help: String
-                                         )(
-                                           implicit _f: Flaggable[T])
-  extends Flag[T](null, help, defaultOrUsage, false) {
+abstract class GlobalFlag[T] private[app] (
+  defaultOrUsage: Either[() => T, String],
+  help: String
+)(
+  implicit _f: Flaggable[T])
+    extends Flag[T](null, help, defaultOrUsage, false) {
 
   override protected[this] def parsingDone: Boolean = true
 
@@ -68,30 +68,30 @@ abstract class GlobalFlag[T] private[app](
     }
 
   /**
-    * $java_declaration
-    *
-    * @param default the default value used if the value is not specified by the user.
-    * @param help    documentation regarding usage of this [[Flag]].
-    */
+   * $java_declaration
+   *
+   * @param default the default value used if the value is not specified by the user.
+   * @param help documentation regarding usage of this [[Flag]].
+   */
   def this(default: T, help: String)(implicit _f: Flaggable[T]) =
     this(Left(() => default), help)
 
   /**
-    * $java_declaration
-    *
-    * @param help documentation regarding usage of this [[Flag]].
-    */
+   * $java_declaration
+   *
+   * @param help documentation regarding usage of this [[Flag]].
+   */
   def this(help: String)(implicit _f: Flaggable[T], m: Manifest[T]) =
     this(Right(m.toString), help)
 
   /**
-    * The "name", or "id", of this [[Flag]].
-    *
-    * While not marked `final`, if a subclass overrides this value, then
-    * developers '''must''' set that flag via System properties as otherwise it
-    * will not be recognized with command-line arguments.
-    * e.g. `-DyourGlobalFlagName=flagName`
-    */
+   * The "name", or "id", of this [[Flag]].
+   *
+   * While not marked `final`, if a subclass overrides this value, then
+   * developers '''must''' set that flag via System properties as otherwise it
+   * will not be recognized with command-line arguments.
+   * e.g. `-DyourGlobalFlagName=flagName`
+   */
   override val name: String = getClass.getName.stripSuffix("$")
 
   protected override def getValue: Option[T] = super.getValue match {
@@ -100,17 +100,17 @@ abstract class GlobalFlag[T] private[app](
   }
 
   /**
-    * Used by [[Flags.parseArgs]] to initialize [[Flag]] values.
-    *
-    * @note Called via reflection assuming it will be a `static`
-    *       method on a singleton `object`. This causes problems
-    *       for Java developers who want to create a [[GlobalFlag]]
-    *       as there is no good means for them to have it be a
-    *       `static` method. Thus, Java devs must add a method
-    *       `public static Flag<?> globalFlagInstance()` which
-    *       returns the singleton instance of the flag.
-    *       See [[JavaGlobalFlag]] for more details.
-    */
+   * Used by [[Flags.parseArgs]] to initialize [[Flag]] values.
+   *
+   * @note Called via reflection assuming it will be a `static`
+   *       method on a singleton `object`. This causes problems
+   *       for Java developers who want to create a [[GlobalFlag]]
+   *       as there is no good means for them to have it be a
+   *       `static` method. Thus, Java devs must add a method
+   *       `public static Flag<?> globalFlagInstance()` which
+   *       returns the singleton instance of the flag.
+   *       See [[JavaGlobalFlag]] for more details.
+   */
   def getGlobalFlag: Flag[_] = this
 }
 

--- a/util-app/src/main/scala/com/twitter/app/JavaGlobalFlag.scala
+++ b/util-app/src/main/scala/com/twitter/app/JavaGlobalFlag.scala
@@ -1,64 +1,62 @@
 package com.twitter.app
 
 /**
- * @define java_declaration
- *
- * In order to declare a new [[GlobalFlag]] in Java, it can be done with a bit
- * of ceremony by following a few steps:
- *
- * 1. the flag's class name must end with "$", e.g. `javaGlobalWithDefault$`.
- * This is done to mimic the behavior of Scala's singleton `object`.
- * 2. the class must have a method, `public static Flag<?> globalFlagInstance()`,
- * that returns the singleton instance of the [[Flag]].
- * 3. the class should have a `static final` field holding the singleton
- * instance of the flag.
- * 4. the class should extend `JavaGlobalFlag`.
- * 5. to avoid extraneous creation of instances, thus forcing users to only
- * access the singleton, the constructor should be `private` and the class
- * should be `public final`.
- *
- * An example of a [[GlobalFlag]] declared in Java:
- * {{{
- * import com.twitter.app.Flag;
- * import com.twitter.app.Flaggable;
- * import com.twitter.app.JavaGlobalFlag;
- *
- * public final class exampleJavaGlobalFlag$ extends JavaGlobalFlag<String> {
- *   private exampleJavaGlobalFlag() {
- *     super("The default value", "The help string", Flaggable.ofString());
- *   }
- *   public static final Flag<String> Flag = new exampleJavaGlobalFlag();
- *   public static Flag<?> globalFlagInstance() {
- *     return Flag;
- *   }
- * }
- * }}}
- */
-abstract class JavaGlobalFlag[T] private (
-  defaultOrUsage: Either[() => T, String],
-  help: String,
-  flaggable: Flaggable[T])
-    extends GlobalFlag[T](defaultOrUsage, help)(flaggable) {
+  * In order to declare a new [[GlobalFlag]] in Java, it can be done with a bit
+  * of ceremony by following a few steps:
+  *
+  *  1. the flag's class name must end with "$", e.g. `javaGlobalWithDefault$`.
+  * This is done to mimic the behavior of Scala's singleton `object`.
+  *  1. the class must have a method, `public static Flag<?> globalFlagInstance()`,
+  * that returns the singleton instance of the [[Flag]].
+  *  1. the class should have a `static final` field holding the singleton
+  * instance of the flag.
+  *  1. the class should extend `JavaGlobalFlag`.
+  *  1. to avoid extraneous creation of instances, thus forcing users to only
+  * access the singleton, the constructor should be `private` and the class
+  * should be `public final`.
+  *
+  * An example of a [[GlobalFlag]] declared in Java:
+  * {{{
+  * import com.twitter.app.Flag;
+  * import com.twitter.app.Flaggable;
+  * import com.twitter.app.JavaGlobalFlag;
+  *
+  * public final class exampleJavaGlobalFlag$ extends JavaGlobalFlag<String> {
+  *   private exampleJavaGlobalFlag() {
+  *     super("The default value", "The help string", Flaggable.ofString());
+  *   }
+  *   public static final Flag<String> Flag = new exampleJavaGlobalFlag();
+  *   public static Flag<?> globalFlagInstance() {
+  *     return Flag;
+  *   }
+  * }
+  * }}}
+  */
+abstract class JavaGlobalFlag[T] private(
+                                          defaultOrUsage: Either[() => T, String],
+                                          help: String,
+                                          flaggable: Flaggable[T])
+  extends GlobalFlag[T](defaultOrUsage, help)(flaggable) {
 
   /**
-   * A flag with a default value.
-   *
-   * $java_declaration
-   *
-   * @param default the default value used if the value is not specified by the user.
-   * @param help documentation regarding usage of this flag.
-   */
+    * A flag with a default value.
+    *
+    * $java_declaration
+    *
+    * @param default the default value used if the value is not specified by the user.
+    * @param help    documentation regarding usage of this flag.
+    */
   protected def this(default: T, help: String, flaggable: Flaggable[T]) =
     this(Left(() => default), help, flaggable)
 
   /**
-   * A flag without a default value.
-   *
-   * $java_declaration
-   *
-   * @param help documentation regarding usage of this flag.
-   * @param clazz the type of the flag
-   */
+    * A flag without a default value.
+    *
+    * $java_declaration
+    *
+    * @param help  documentation regarding usage of this flag.
+    * @param clazz the type of the flag
+    */
   protected def this(help: String, flaggable: Flaggable[T], clazz: Class[T]) =
     this(Right(clazz.getName), help, flaggable)
 

--- a/util-app/src/main/scala/com/twitter/app/JavaGlobalFlag.scala
+++ b/util-app/src/main/scala/com/twitter/app/JavaGlobalFlag.scala
@@ -1,62 +1,62 @@
 package com.twitter.app
 
 /**
-  * In order to declare a new [[GlobalFlag]] in Java, it can be done with a bit
-  * of ceremony by following a few steps:
-  *
-  *  1. the flag's class name must end with "$", e.g. `javaGlobalWithDefault$`.
-  * This is done to mimic the behavior of Scala's singleton `object`.
-  *  1. the class must have a method, `public static Flag<?> globalFlagInstance()`,
-  * that returns the singleton instance of the [[Flag]].
-  *  1. the class should have a `static final` field holding the singleton
-  * instance of the flag.
-  *  1. the class should extend `JavaGlobalFlag`.
-  *  1. to avoid extraneous creation of instances, thus forcing users to only
-  * access the singleton, the constructor should be `private` and the class
-  * should be `public final`.
-  *
-  * An example of a [[GlobalFlag]] declared in Java:
-  * {{{
-  * import com.twitter.app.Flag;
-  * import com.twitter.app.Flaggable;
-  * import com.twitter.app.JavaGlobalFlag;
-  *
-  * public final class exampleJavaGlobalFlag$ extends JavaGlobalFlag<String> {
-  *   private exampleJavaGlobalFlag() {
-  *     super("The default value", "The help string", Flaggable.ofString());
-  *   }
-  *   public static final Flag<String> Flag = new exampleJavaGlobalFlag();
-  *   public static Flag<?> globalFlagInstance() {
-  *     return Flag;
-  *   }
-  * }
-  * }}}
-  */
-abstract class JavaGlobalFlag[T] private(
-                                          defaultOrUsage: Either[() => T, String],
-                                          help: String,
-                                          flaggable: Flaggable[T])
-  extends GlobalFlag[T](defaultOrUsage, help)(flaggable) {
+ * In order to declare a new [[GlobalFlag]] in Java, it can be done with a bit
+ * of ceremony by following a few steps:
+ *
+ *  1. the flag's class name must end with "$", e.g. `javaGlobalWithDefault$`.
+ *  This is done to mimic the behavior of Scala's singleton `object`.
+ *  1. the class must have a method, `public static Flag<?> globalFlagInstance()`,
+ *  that returns the singleton instance of the [[Flag]].
+ *  1. the class should have a `static final` field holding the singleton
+ *  instance of the flag.
+ *  1. the class should extend `JavaGlobalFlag`.
+ *  1. to avoid extraneous creation of instances, thus forcing users to only
+ *  access the singleton, the constructor should be `private` and the class
+ *  should be `public final`.
+ *
+ * An example of a [[GlobalFlag]] declared in Java:
+ * {{{
+ * import com.twitter.app.Flag;
+ * import com.twitter.app.Flaggable;
+ * import com.twitter.app.JavaGlobalFlag;
+ *
+ * public final class exampleJavaGlobalFlag$ extends JavaGlobalFlag<String> {
+ *   private exampleJavaGlobalFlag() {
+ *     super("The default value", "The help string", Flaggable.ofString());
+ *   }
+ *   public static final Flag<String> Flag = new exampleJavaGlobalFlag();
+ *   public static Flag<?> globalFlagInstance() {
+ *     return Flag;
+ *   }
+ * }
+ * }}}
+ */
+abstract class JavaGlobalFlag[T] private (
+  defaultOrUsage: Either[() => T, String],
+  help: String,
+  flaggable: Flaggable[T])
+    extends GlobalFlag[T](defaultOrUsage, help)(flaggable) {
 
   /**
-    * A flag with a default value.
-    *
-    * $java_declaration
-    *
-    * @param default the default value used if the value is not specified by the user.
-    * @param help    documentation regarding usage of this flag.
-    */
+   * A flag with a default value.
+   *
+   * $java_declaration
+   *
+   * @param default the default value used if the value is not specified by the user.
+   * @param help documentation regarding usage of this flag.
+   */
   protected def this(default: T, help: String, flaggable: Flaggable[T]) =
     this(Left(() => default), help, flaggable)
 
   /**
-    * A flag without a default value.
-    *
-    * $java_declaration
-    *
-    * @param help  documentation regarding usage of this flag.
-    * @param clazz the type of the flag
-    */
+   * A flag without a default value.
+   *
+   * $java_declaration
+   *
+   * @param help documentation regarding usage of this flag.
+   * @param clazz the type of the flag
+   */
   protected def this(help: String, flaggable: Flaggable[T], clazz: Class[T]) =
     this(Right(clazz.getName), help, flaggable)
 

--- a/util-app/src/main/scala/com/twitter/app/JavaGlobalFlag.scala
+++ b/util-app/src/main/scala/com/twitter/app/JavaGlobalFlag.scala
@@ -8,12 +8,12 @@ package com.twitter.app
  *
  * 1. the flag's class name must end with "$", e.g. `javaGlobalWithDefault$`.
  * This is done to mimic the behavior of Scala's singleton `object`.
- * 1. the class must have a method, `public static Flag<?> globalFlagInstance()`,
+ * 2. the class must have a method, `public static Flag<?> globalFlagInstance()`,
  * that returns the singleton instance of the [[Flag]].
- * 1. the class should have a `static final` field holding the singleton
+ * 3. the class should have a `static final` field holding the singleton
  * instance of the flag.
- * 1. the class should extend `JavaGlobalFlag`.
- * 1. to avoid extraneous creation of instances, thus forcing users to only
+ * 4. the class should extend `JavaGlobalFlag`.
+ * 5. to avoid extraneous creation of instances, thus forcing users to only
  * access the singleton, the constructor should be `private` and the class
  * should be `public final`.
  *

--- a/util-app/src/test/scala/com/twitter/app/GlobalFlagTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/GlobalFlagTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.FunSuite
 import org.scalatest.mockito.MockitoSugar._
 import org.mockito.Mockito.when
 import org.mockito.Matchers._
+import org.mockito.invocation.InvocationOnMock
 
 object MyGlobalFlag extends GlobalFlag[String]("a test flag", "a global test flag")
 
@@ -73,7 +74,7 @@ class GlobalFlagTest extends FunSuite {
   }
 
   test("GlobalFlag.getAll") {
-    val isValidClassName: ArgumentMatcher[String] = { className =>
+    val isValidClassName: ArgumentMatcher[String] = { className: Any =>
       List(MyGlobalFlag, MyGlobalBooleanFlag, MyGlobalFlagNoDefault, PackageObjectTest)
         .map(_.getClass.getName)
         .contains(className)
@@ -81,7 +82,7 @@ class GlobalFlagTest extends FunSuite {
     val realClassLoader = getSystemClassLoader.asInstanceOf[URLClassLoader]
     val mockClassLoader = mock[URLClassLoader]
     when(mockClassLoader.getURLs).thenReturn(realClassLoader.getURLs)
-    when(mockClassLoader.loadClass(argThat(isValidClassName))).thenAnswer { inv =>
+    when(mockClassLoader.loadClass(argThat(isValidClassName))).thenAnswer { inv: InvocationOnMock =>
       realClassLoader.loadClass(inv.getArgumentAt(0, classOf[String]))
     }
     val flags = GlobalFlag.getAll(mockClassLoader)

--- a/util-app/src/test/scala/com/twitter/app/GlobalFlagTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/GlobalFlagTest.scala
@@ -63,4 +63,10 @@ class GlobalFlagTest extends FunSuite {
     }
   }
 
+  test("GlobalFlag.getAll") {
+    val flags = GlobalFlag.getAll(getClass.getClassLoader)
+    assert(flags.length == 9)
+    assert(flags.exists(_.help.equals("a package object test flag")))
+  }
+
 }

--- a/util-app/src/test/scala/com/twitter/app/package.scala
+++ b/util-app/src/test/scala/com/twitter/app/package.scala
@@ -1,0 +1,5 @@
+package com.twitter
+
+package object app {
+  object packageObjectTest extends GlobalFlag[Boolean](true, "a package object test flag")
+}

--- a/util-app/src/test/scala/com/twitter/app/package.scala
+++ b/util-app/src/test/scala/com/twitter/app/package.scala
@@ -1,5 +1,5 @@
 package com.twitter
 
 package object app {
-  object packageObjectTest extends GlobalFlag[Boolean](true, "a package object test flag")
+  object PackageObjectTest extends GlobalFlag[Boolean](true, "a package object test flag")
 }


### PR DESCRIPTION
Problem

`GlobalFlag.getAll()` fails to validate flags defined within a package object. This is caused by Scala compiler not creating static forwarders for objects defined within a package object, so the necessary method can't be called via reflection. 

Solution

Instead of relying on static forwarders, now we're getting Flag object through `MODULE$` field

Result

You can now define global flags within package objects.
