### PR TITLE
util-jvm: Fix invocation of GarbageCollectionNotificationInfo.from()

### DIFF
--- a/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
@@ -257,7 +257,7 @@ private object Hotspot {
    */
   def gcFromNotificationInfo(compositeData: CompositeData): Gc = {
     val gcNotifInfo /* com.sun.management.GarbageCollectionNotificationInfo */ =
-      gcNotifInfoFromMethod.invoke(compositeData)
+      gcNotifInfoFromMethod.invoke(null, compositeData)
     val gcInfo /* com.sun.management.GcInfo */ =
       gcNotifInfoGetGcInfoMethod.invoke(gcNotifInfo)
     Gc(


### PR DESCRIPTION
Problem

Currently, `Hotspot.gcFromNotificationInfo()` causes a following exception: 

```
java.lang.IllegalArgumentException: wrong number of arguments
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.twitter.jvm.Hotspot$.gcFromNotificationInfo(Hotspot.scala:260)
	at com.twitter.jvm.Hotspot$$anon$1.handleNotification(Hotspot.scala:95)
	at sun.management.NotificationEmitterSupport.sendNotification(NotificationEmitterSupport.java:156)
	at sun.management.GarbageCollectorImpl.createGCNotification(GarbageCollectorImpl.java:143)
```

Solution

Give `null` as the receiver of invocation of `GarbageCollectionNotificationInfo.from()` which uses reflection because this method is static.
