### PR TITLE
doc: Remove unused parameter in Future conversion example

### DIFF
--- a/doc/src/sphinx/util-cookbook/futures.rst
+++ b/doc/src/sphinx/util-cookbook/futures.rst
@@ -29,7 +29,7 @@ Scala:
 
   /** Convert from a Twitter Future to a Scala Future */
   implicit class RichTwitterFuture[A](val tf: TwitterFuture[A]) extends AnyVal {
-    def asScala(implicit e: ExecutionContext): ScalaFuture[A] = {
+    def asScala(): ScalaFuture[A] = {
       val promise: ScalaPromise[A] = ScalaPromise()
       tf.respond {
         case Return(value) => promise.success(value)


### PR DESCRIPTION
**Problem**

`asScala` method in the first example of the Futures documentation passes in an unused parameter `implicit e: ExecutionContext`.

**Solution**

Removed unused parameter. 

Fixes #246.
