### PR TITLE
Update to 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_cache:
 scala:
   - 2.11.12
   - 2.12.8
+  - 2.13.0
 
 jdk:
   - oraclejdk8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ locally).
 When appropriate, use [ScalaCheck][scalacheck] to write property-based
 tests for your code. This will often produce more thorough and effective
 inputs for your tests. We use ScalaTest's
-[GeneratorDrivenPropertyChecks][gendrivenprop] as the entry point for
+[ScalaCheckDrivenPropertyChecks][gendrivenprop] as the entry point for
 writing these tests.
 
 ## Compatibility

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion
 
 val defaultProjectSettings = Seq(
   scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.11.12", "2.12.8")
+  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
 )
 
 val baseSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,12 @@ val zkDependency = "org.apache.zookeeper" % "zookeeper" % zkVersion excludeAll(
   ExclusionRule("javax.jms", "jms")
 )
 val slf4jVersion = "1.7.21"
-val jacksonVersion = "2.9.8"
+val jacksonVersion = "2.9.9"
 
 val guavaLib = "com.google.guava" % "guava" % "19.0"
 val caffeineLib = "com.github.ben-manes.caffeine" % "caffeine" % "2.3.4"
 val jsr305Lib = "com.google.code.findbugs" % "jsr305" % "2.0.1"
-val scalacheckLib = "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
+val scalacheckLib = "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
 val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion
 
 val defaultProjectSettings = Seq(
@@ -32,10 +32,19 @@ val baseSettings = Seq(
   unmanagedClasspath in Compile += Attributed.blank(new java.io.File("doesnotexist")),
   libraryDependencies ++= Seq(
     // See https://www.scala-sbt.org/0.13/docs/Testing.html#JUnit
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1",
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.mockito" % "mockito-all" % "1.10.19" % "test",
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.8" % "test"
   ),
+  fork in Test := true,
+  unmanagedSourceDirectories in Compile += {
+    val sourceDir = (sourceDirectory in Compile).value
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
+      case _ => sourceDir / "scala-2.12-"
+    }
+  },
 
   ScoverageKeys.coverageHighlighting := true,
   resolvers +=
@@ -48,7 +57,8 @@ val baseSettings = Seq(
     "-feature",
     "-encoding", "utf8",
     // Needs -missing-interpolator due to https://issues.scala-lang.org/browse/SI-8761
-    "-Xlint:-missing-interpolator"
+    "-Xlint:-missing-interpolator",
+    "-Yrangepos"
   ),
 
   // Note: Use -Xlint rather than -Xlint:unchecked when TestThriftStructure
@@ -216,7 +226,7 @@ lazy val utilCore = Project(
     caffeineLib % "test",
     scalacheckLib,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
   ),
   resourceGenerators in Compile += Def.task {
     val projectName = name.value
@@ -368,7 +378,14 @@ lazy val utilStats = Project(
   sharedSettings
 ).settings(
   name := "util-stats",
-  libraryDependencies ++= Seq(caffeineLib, jsr305Lib, scalacheckLib)
+  libraryDependencies ++= Seq(caffeineLib, jsr305Lib, scalacheckLib) ++ {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, major)) if major >= 13 =>
+        Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0" % "test")
+      case _ =>
+        Seq()
+  }
+}
 ).dependsOn(utilCore, utilLint)
 
 lazy val utilTest = Project(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC2
+sbt.version=1.3.0-RC3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.3.0-RC2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,5 @@ resolvers += Classpaths.sbtPluginReleases
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.0")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")

--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Logger
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.collection.Seq
 import scala.util.control.NonFatal
 
 /**

--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Logger
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.collection.Seq
 import scala.util.control.NonFatal
 
 /**
@@ -314,7 +313,7 @@ trait App extends Closable with CloseAwaitably {
     deadline: Time
   ): Future[Unit] = {
     Future
-      .collectToTry(lastExits.asScala.toSeq.map(_.close(deadline)))
+      .collectToTry(lastExits.asScala.map(_.close(deadline)).toSeq)
       .by(shutdownTimer, deadline)
       .transform {
         case Return(results) =>

--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -313,7 +313,7 @@ trait App extends Closable with CloseAwaitably {
     deadline: Time
   ): Future[Unit] = {
     Future
-      .collectToTry(lastExits.asScala.map(_.close(deadline)).toSeq)
+      .collectToTry(lastExits.asScala.toSeq.map(_.close(deadline)))
       .by(shutdownTimer, deadline)
       .transform {
         case Return(results) =>

--- a/util-app/src/main/scala/com/twitter/app/ClassPath.scala
+++ b/util-app/src/main/scala/com/twitter/app/ClassPath.scala
@@ -161,7 +161,7 @@ private[app] sealed abstract class ClassPath[CpInfo <: ClassPath.Info] {
 
   private def jarClasspath(jarFile: File, manifest: java.util.jar.Manifest): Seq[URI] =
     for {
-      m  <- Option(manifest).toSeq
+      m <- Option(manifest).toSeq
       attr <- Option(m.getMainAttributes.getValue("Class-Path")).toSeq
       el <- attr.split(" ").toSeq
       uri <- uriFromJarClasspath(jarFile, el)

--- a/util-app/src/main/scala/com/twitter/app/ClassPath.scala
+++ b/util-app/src/main/scala/com/twitter/app/ClassPath.scala
@@ -228,7 +228,7 @@ private[app] class LoadServiceClassPath extends ClassPath[ClassPath.LoadServiceI
 
   private[app] def readLines(source: Source): Seq[String] = {
     try {
-      source.getLines().toArray.flatMap { line =>
+      source.getLines().toVector.flatMap { line =>
         val commentIdx = line.indexOf('#')
         val end = if (commentIdx != -1) commentIdx else line.length
         val str = line.substring(0, end).trim

--- a/util-app/src/main/scala/com/twitter/app/Flaggable.scala
+++ b/util-app/src/main/scala/com/twitter/app/Flaggable.scala
@@ -172,14 +172,14 @@ object Flaggable {
   private[app] class SetFlaggable[T: Flaggable] extends Flaggable[Set[T]] {
     private val flag = implicitly[Flaggable[T]]
     assert(flag.default.isEmpty)
-    override def parse(v: String): Set[T] = v.split(",").map(flag.parse(_)).toSet
+    override def parse(v: String): Set[T] = v.split(",").iterator.map(flag.parse(_)).toSet
     override def show(set: Set[T]): String = set.map(flag.show).mkString(",")
   }
 
   private[app] class SeqFlaggable[T: Flaggable] extends Flaggable[Seq[T]] {
     private val flag = implicitly[Flaggable[T]]
     assert(flag.default.isEmpty)
-    def parse(v: String): Seq[T] = v.split(",").map(flag.parse)
+    def parse(v: String): Seq[T] = v.split(",").toSeq.map(flag.parse)
     override def show(seq: Seq[T]): String = seq.map(flag.show).mkString(",")
   }
 
@@ -225,7 +225,7 @@ object Flaggable {
   implicit def ofJavaList[T: Flaggable]: Flaggable[JList[T]] = new Flaggable[JList[T]] {
     val seqFlaggable = new SeqFlaggable[T]
     override def parse(v: String): JList[T] = seqFlaggable.parse(v).asJava
-    override def show(list: JList[T]): String = seqFlaggable.show(list.asScala)
+    override def show(list: JList[T]): String = seqFlaggable.show(list.asScala.toSeq)
   }
 
   implicit def ofJavaMap[K: Flaggable, V: Flaggable]: Flaggable[JMap[K, V]] = {

--- a/util-app/src/main/scala/com/twitter/app/Flags.scala
+++ b/util-app/src/main/scala/com/twitter/app/Flags.scala
@@ -379,7 +379,7 @@ class Flags(argv0: String, includeGlobal: Boolean, failFastUntilParsed: Boolean)
   ): (Iterable[String], Iterable[String]) = {
     val (set, unset) = getAll(includeGlobal, classLoader).partition { _.get.isDefined }
 
-    (set.map { _ + " \\" }, unset.map { _ + " \\" })
+    (set.map { _.toString + " \\" }, unset.map { _.toString + " \\" })
   }
 
   /**

--- a/util-app/src/main/scala/com/twitter/app/Flags.scala
+++ b/util-app/src/main/scala/com/twitter/app/Flags.scala
@@ -196,7 +196,7 @@ class Flags(argv0: String, includeGlobal: Boolean, failFastUntilParsed: Boolean)
       if (helpFlag())
         Help(usage)
       else
-        Ok(remaining)
+        Ok(remaining.toSeq)
     }
 
   /**

--- a/util-app/src/main/scala/com/twitter/app/GlobalFlag.scala
+++ b/util-app/src/main/scala/com/twitter/app/GlobalFlag.scala
@@ -159,7 +159,7 @@ object GlobalFlag {
       //we don't hide the real issue that a developer just added an unparseable arg.
       case e: Throwable =>
         log.log(java.util.logging.Level.SEVERE, "failure reading in flags", e)
-        new ArrayBuffer[Flag[_]]
+        Nil
     }
   }
 
@@ -172,7 +172,7 @@ object GlobalFlag {
       className.endsWith("$") && !className.endsWith("package$")
 
     val markerClass = classOf[GlobalFlagVisible]
-    val flags = new ArrayBuffer[Flag[_]]
+    val flagBuilder = new scala.collection.immutable.VectorBuilder[Flag[_]]
 
     // Search for Scala objects annotated with GlobalFlagVisible:
     val cp = new FlagClassPath()
@@ -181,7 +181,8 @@ object GlobalFlag {
         val cls: Class[_] = Class.forName(info.className, false, loader)
         if (cls.isAnnotationPresent(markerClass)) {
           get(info.className) match {
-            case Some(f) => flags += f
+            case Some(f) =>
+              flagBuilder += f
             case None => println("failed for " + info.className)
           }
         }
@@ -189,6 +190,6 @@ object GlobalFlag {
         case _: IllegalStateException | _: NoClassDefFoundError | _: ClassNotFoundException =>
       }
     }
-    flags
+    flagBuilder.result()
   }
 }

--- a/util-app/src/main/scala/com/twitter/app/LoadService.scala
+++ b/util-app/src/main/scala/com/twitter/app/LoadService.scala
@@ -41,7 +41,7 @@ object LoadService {
      * @param implementations cannot be empty.
      */
     def this(iface: Class[T], implementations: java.util.List[T]) =
-      this(iface, implementations.asScala)
+      this(iface, implementations.asScala.toSeq)
 
     if (implementations.isEmpty) {
       throw new IllegalArgumentException("implementations cannot be empty")
@@ -157,7 +157,7 @@ object LoadService {
     val cp = new LoadServiceClassPath()
     val whenAbsent = new JFunction[ClassLoader, Seq[ClassPath.LoadServiceInfo]] {
       def apply(loader: ClassLoader): Seq[ClassPath.LoadServiceInfo] = {
-        cp.browse(loader)
+        cp.browse(loader).toSeq
       }
     }
 

--- a/util-app/src/test/scala/com/twitter/app/ClassPathTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/ClassPathTest.scala
@@ -3,7 +3,7 @@ package com.twitter.app
 import java.net.URLClassLoader
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ClassPathTest extends FunSuite with MockitoSugar {
 

--- a/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
@@ -9,7 +9,8 @@ import java.io.{File, InputStream}
 import java.net.URL
 import java.util
 import java.util.concurrent.{Callable, CountDownLatch, ExecutorService, Executors}
-import java.util.{Random, concurrent}
+import java.util.concurrent.{Future => JFuture}
+import java.util.Random
 import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.mutable
@@ -140,7 +141,7 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
     // Run LoadService in a different thread from the custom classloader
     val clazz: Class[_] = loader.loadClass("com.twitter.app.LoadServiceCallable")
     val executor: ExecutorService = Executors.newSingleThreadExecutor()
-    val future: concurrent.Future[Seq[Any]] =
+    val future: JFuture[Seq[Any]] =
       executor.submit(clazz.newInstance().asInstanceOf[Callable[Seq[Any]]])
 
     // Get the result
@@ -262,7 +263,6 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
     assert(lsds0.size == 1)
     assert(lsds0.head.getClass == classOf[LoadServiceDeadlockImpl])
   }
-
 }
 
 class LoadServiceCallable extends Callable[Seq[Any]] {

--- a/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
@@ -99,7 +99,7 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
 
   test("LoadService shouldn't fail on un-readable dir") {
     val loader = mock[ClassLoader]
-    val buf = mutable.Buffer.empty[ClassPath.LoadServiceInfo]
+    val buf = Vector.newBuilder[ClassPath.LoadServiceInfo]
     val rand = new Random()
 
     val f = File.createTempFile("tmp", "__utilapp_loadservice" + rand.nextInt(10000))
@@ -108,14 +108,14 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
       f.setReadable(false)
 
       new LoadServiceClassPath().browseUri(f.toURI, loader, buf)
-      assert(buf.isEmpty)
+      assert(buf.result.isEmpty)
       f.delete()
     }
   }
 
   test("LoadService shouldn't fail on un-readable sub-dir") {
     val loader = mock[ClassLoader]
-    val buf = mutable.Buffer.empty[ClassPath.LoadServiceInfo]
+    val buf = Vector.newBuilder[ClassPath.LoadServiceInfo]
     val rand = new Random()
 
     val f = File.createTempFile("tmp", "__utilapp_loadservice" + rand.nextInt(10000))
@@ -127,7 +127,7 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
       subDir.setReadable(false)
 
       new LoadServiceClassPath().browseUri(f.toURI, loader, buf)
-      assert(buf.isEmpty)
+      assert(buf.result.isEmpty)
 
       subDir.delete()
       f.delete()
@@ -165,7 +165,7 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
       val jos = new JarOutputStream(new FileOutputStream(jarFile), manifest)
       jos.close()
       val loader = mock[ClassLoader]
-      val buf = mutable.Buffer.empty[ClassPath.LoadServiceInfo]
+      val buf = Vector.newBuilder[ClassPath.LoadServiceInfo]
       new LoadServiceClassPath().browseUri(jarFile.toURI, loader, buf)
     } finally {
       jarFile.delete
@@ -187,7 +187,7 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
       attributes.put(CLASS_PATH, jar1.getName)
       new JarOutputStream(new FileOutputStream(jar2), manifest).close()
       val loader = mock[ClassLoader]
-      val buf = mutable.Buffer.empty[ClassPath.LoadServiceInfo]
+      val buf = Vector.newBuilder[ClassPath.LoadServiceInfo]
       new LoadServiceClassPath().browseUri(jar1.toURI, loader, buf)
     } finally {
       jar1.delete

--- a/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
@@ -11,7 +11,7 @@ import java.util
 import java.util.concurrent.{Callable, CountDownLatch, ExecutorService, Executors}
 import java.util.{Random, concurrent}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.mutable
 
 // These traits correspond to files in:

--- a/util-benchmark/src/main/scala/com/twitter/concurrent/OfferBenchmark.scala
+++ b/util-benchmark/src/main/scala/com/twitter/concurrent/OfferBenchmark.scala
@@ -5,6 +5,7 @@ import com.twitter.util.{Future, Promise}
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.Seq
 import scala.util.Random
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/util-benchmark/src/main/scala/com/twitter/concurrent/OfferBenchmark.scala
+++ b/util-benchmark/src/main/scala/com/twitter/concurrent/OfferBenchmark.scala
@@ -5,7 +5,6 @@ import com.twitter.util.{Future, Promise}
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.Seq
 import scala.util.Random
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -57,7 +56,7 @@ object OfferBenchmark {
 
       ps(rng.nextInt(numToChooseFrom)).setValue(Tx.const(5))
 
-      ofs
+      ofs.toSeq
     }
   }
 }

--- a/util-benchmark/src/main/scala/com/twitter/util/FutureBenchmark.scala
+++ b/util-benchmark/src/main/scala/com/twitter/util/FutureBenchmark.scala
@@ -2,6 +2,7 @@ package com.twitter.util
 
 import com.twitter.concurrent.Offer
 import org.openjdk.jmh.annotations._
+import scala.collection.Seq
 
 // ./sbt 'project util-benchmark' 'jmh:run FutureBenchmark'
 class FutureBenchmark extends StdBenchAnnotations {

--- a/util-benchmark/src/main/scala/com/twitter/util/FutureBenchmark.scala
+++ b/util-benchmark/src/main/scala/com/twitter/util/FutureBenchmark.scala
@@ -2,7 +2,6 @@ package com.twitter.util
 
 import com.twitter.concurrent.Offer
 import org.openjdk.jmh.annotations._
-import scala.collection.Seq
 
 // ./sbt 'project util-benchmark' 'jmh:run FutureBenchmark'
 class FutureBenchmark extends StdBenchAnnotations {

--- a/util-cache/src/test/scala/com/twitter/cache/EvictingCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/EvictingCacheTest.scala
@@ -4,7 +4,7 @@ import com.twitter.util.{Promise, Future}
 import java.util.concurrent.ConcurrentHashMap
 import org.mockito.Mockito.{verify, never}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class EvictingCacheTest extends FunSuite with MockitoSugar {
   test("EvictingCache should evict on failed futures for set") {

--- a/util-cache/src/test/scala/com/twitter/cache/LazilyEvictingCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/LazilyEvictingCacheTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Future, Promise}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class LazilyEvictingCacheTest extends FunSuite with MockitoSugar {
   private val explodingCacheLoader =

--- a/util-cache/src/test/scala/com/twitter/cache/RefreshTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/RefreshTest.scala
@@ -4,7 +4,7 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, Promise, Time}
 import org.mockito.Mockito._
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RefreshTest extends FunSuite with MockitoSugar {
 

--- a/util-core/concurrent-extra/src/main/scala/com/twitter/concurrent/Offer.scala
+++ b/util-core/concurrent-extra/src/main/scala/com/twitter/concurrent/Offer.scala
@@ -2,6 +2,7 @@ package com.twitter.concurrent
 
 import com.twitter.util.{Await, Duration, Future, Promise, Time, Timer}
 import com.twitter.util.Return
+import scala.collection.compat.immutable.ArraySeq
 import scala.util.Random
 
 /**
@@ -280,7 +281,7 @@ object Offer {
           if (foundPos >= 0) {
             updateLosers(foundPos, prepd)
           } else {
-            Future.selectIndex(prepd) flatMap { winPos =>
+            Future.selectIndex(ArraySeq.unsafeWrapArray(prepd)) flatMap { winPos =>
               updateLosers(winPos, prepd)
             }
           }

--- a/util-core/concurrent-extra/src/main/scala/com/twitter/concurrent/Offer.scala
+++ b/util-core/concurrent-extra/src/main/scala/com/twitter/concurrent/Offer.scala
@@ -3,7 +3,6 @@ package com.twitter.concurrent
 import com.twitter.util.{Await, Duration, Future, Promise, Time, Timer}
 import com.twitter.util.Return
 import scala.util.Random
-import scala.collection.Seq
 
 /**
  * An offer to communicate with another process. The offer is

--- a/util-core/concurrent-extra/src/main/scala/com/twitter/concurrent/Offer.scala
+++ b/util-core/concurrent-extra/src/main/scala/com/twitter/concurrent/Offer.scala
@@ -3,6 +3,7 @@ package com.twitter.concurrent
 import com.twitter.util.{Await, Duration, Future, Promise, Time, Timer}
 import com.twitter.util.Return
 import scala.util.Random
+import scala.collection.Seq
 
 /**
  * An offer to communicate with another process. The offer is
@@ -206,6 +207,7 @@ object Offer {
    * The offer that chooses exactly one of the given offers. If there are any
    * Offers that are synchronizable immediately, one is chosen at random.
    */
+  @scala.annotation.varargs
   def choose[T](evs: Offer[T]*): Offer[T] = choose(rng, evs)
 
   /**

--- a/util-core/src/main/java/com/twitter/concurrent/Offers.java
+++ b/util-core/src/main/java/com/twitter/concurrent/Offers.java
@@ -60,7 +60,7 @@ public final class Offers {
    * @see Offer$#choose(scala.collection.Seq)
    */
   public static <T> Offer<T> choose(Collection<Offer<T>> offers) {
-    scala.collection.Seq<Offer<T>> scalaSeq = JavaConverters.collectionAsScalaIterableConverter(offers).asScala().toSeq();
+    scala.collection.immutable.Seq<Offer<T>> scalaSeq = JavaConverters.collectionAsScalaIterableConverter(offers).asScala().toVector();
     return Offer$.MODULE$.choose(scalaSeq);
   }
 

--- a/util-core/src/main/java/com/twitter/concurrent/Spools.java
+++ b/util-core/src/main/java/com/twitter/concurrent/Spools.java
@@ -5,6 +5,7 @@ import com.twitter.util.Future;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.immutable.List;
+import scala.collection.immutable.Nil$;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,7 +27,7 @@ public final class Spools {
    */
   @SuppressWarnings("unchecked")
   public static <T> Spool<T> newSpool(Collection<T> elems) {
-    List<T> buffer = (List<T>)List.empty();
+    List<T> buffer = (List<T>)Nil$.MODULE$;
     for (T item : elems) {
       buffer = buffer.$colon$colon(item);
     }

--- a/util-core/src/main/java/com/twitter/util/Closables.java
+++ b/util-core/src/main/java/com/twitter/util/Closables.java
@@ -50,9 +50,7 @@ public final class Closables {
    * @see com.twitter.util.Closable$#sequence(scala.collection.Seq)
    */
   public static Closable sequence(Closable... closables) {
-    return Closable$.MODULE$.sequence(
-      scala.collection.mutable.WrappedArray$.MODULE$.make(closables)
-    );
+    return Closable$.MODULE$.sequence(closables);
   }
 
   /**

--- a/util-core/src/main/scala-2.12-/twitter/util/HealthyQueue.scala
+++ b/util-core/src/main/scala-2.12-/twitter/util/HealthyQueue.scala
@@ -1,0 +1,39 @@
+package com.twitter.util
+
+import scala.collection.mutable
+
+private[util] class HealthyQueue[A](makeItem: () => Future[A], numItems: Int, isHealthy: A => Boolean)
+    extends mutable.Queue[Future[A]] {
+
+  0.until(numItems) foreach { _ =>
+    this += makeItem()
+  }
+
+  override def +=(elem: Future[A]): HealthyQueue.this.type = synchronized {
+    super.+=(elem)
+  }
+
+  override def +=:(elem: Future[A]): HealthyQueue.this.type = synchronized {
+    super.+=:(elem)
+  }
+
+  override def enqueue(elems: Future[A]*): Unit = synchronized {
+    super.enqueue(elems: _*)
+  }
+
+  override def dequeue(): Future[A] = synchronized {
+    if (isEmpty) throw new NoSuchElementException("queue empty")
+
+    super.dequeue() flatMap { item =>
+      if (isHealthy(item)) {
+        Future(item)
+      } else {
+        val item = makeItem()
+        synchronized {
+          super.enqueue(item)
+          dequeue()
+        }
+      }
+    }
+  }
+}

--- a/util-core/src/main/scala-2.13+/twitter/util/HealthyQueue.scala
+++ b/util-core/src/main/scala-2.13+/twitter/util/HealthyQueue.scala
@@ -1,0 +1,42 @@
+package com.twitter.util
+
+import scala.collection.mutable
+
+private[util] class HealthyQueue[A](makeItem: () => Future[A], numItems: Int, isHealthy: A => Boolean)
+    extends scala.collection.mutable.Queue[Future[A]] {
+
+  0.until(numItems) foreach { _ =>
+    this += makeItem()
+  }
+
+  override def addOne(elem: Future[A]): HealthyQueue.this.type = synchronized {
+    super.addOne(elem)
+  }
+
+  override def prepend(elem: Future[A]): HealthyQueue.this.type = synchronized {
+    super.prepend(elem)
+  }
+
+  override def enqueue(elem: Future[A]) = synchronized {
+      super.enqueue(elem)
+  }
+  override def enqueue(elem1: Future[A], elem2: Future[A], elems: Future[A]*) = synchronized {
+    super.enqueue(elem1, elem2, elems :_*)
+  }
+
+  override def dequeue(): Future[A] = synchronized {
+    if (isEmpty) throw new NoSuchElementException("queue empty")
+
+    super.dequeue() flatMap { item =>
+      if (isHealthy(item)) {
+        Future(item)
+      } else {
+        val item = makeItem()
+        synchronized {
+          super.enqueue(item)
+          dequeue()
+        }
+      }
+    }
+  }
+}

--- a/util-core/src/main/scala/com/twitter/concurrent/AsyncSemaphore.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/AsyncSemaphore.scala
@@ -116,7 +116,7 @@ class AsyncSemaphore protected (initialPermits: Int, maxWaiters: Option[Int]) {
    *         or a Future.Exception[RejectedExecutionException]` if the configured maximum
    *         number of waiters would be exceeded.
    */
-  def acquire(): Future[Permit] = lock.synchronized {
+  def acquire(): com.twitter.util.Future[Permit] = lock.synchronized {
     if (closed.isDefined)
       return Future.exception(closed.get)
 

--- a/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
@@ -650,9 +650,8 @@ object AsyncStream {
    * Transformation (or lift) from [[Seq]] into `AsyncStream`.
    */
   def fromSeq[A](seq: Seq[A]): AsyncStream[A] = seq match {
-    case Nil => empty
-    case _ if seq.hasDefiniteSize && seq.tail.isEmpty => of(seq.head)
-    case _ => seq.head +:: fromSeq(seq.tail)
+    case head +: tail => head +:: fromSeq(tail)
+    case _ => empty
   }
 
   /**

--- a/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
@@ -3,6 +3,8 @@ package com.twitter.concurrent
 import com.twitter.util.{Future, Return, Throw, Promise}
 import scala.annotation.varargs
 import scala.collection.mutable
+import scala.collection.Seq
+import scala.collection.immutable.{Seq => ISeq}
 
 /**
  * A representation of a lazy (and possibly infinite) sequence of asynchronous
@@ -448,7 +450,7 @@ sealed abstract class AsyncStream[+A] {
    * Note: forces the entire stream. If one asynchronous call fails, it fails
    * the aggregated result.
    */
-  def toSeq(): Future[Seq[A]] =
+  def toSeq(): Future[ISeq[A]] =
     observe().flatMap {
       case (s, None) => Future.value(s)
       case (_, Some(exc)) => Future.exception(exc)
@@ -462,7 +464,7 @@ sealed abstract class AsyncStream[+A] {
    *
    * Note: forces the stream. For infinite streams, the future never resolves.
    */
-  def observe(): Future[(Seq[A], Option[Throwable])] = {
+  def observe(): Future[(ISeq[A], Option[Throwable])] = {
     val buf: mutable.ListBuffer[A] = mutable.ListBuffer.empty
 
     def go(as: AsyncStream[A]): Future[Unit] =
@@ -497,7 +499,7 @@ sealed abstract class AsyncStream[+A] {
    */
   private[concurrent] def buffer(n: Int): Future[(Seq[A], () => AsyncStream[A])] = {
     // pre-allocate the buffer, unless it's very large
-    val buffer = new mutable.ArrayBuffer[A](n.min(1024))
+    val buffer = new mutable.ArrayBuffer[A](n.max(0).min(1024))
 
     def fillBuffer(
       sizeRemaining: Int
@@ -624,11 +626,8 @@ object AsyncStream {
    * {{{
    * AsyncStream(1,2,3)
    * }}}
-   *
-   * Note: we can't annotate this with varargs because of
-   * https://issues.scala-lang.org/browse/SI-8743. This seems to be fixed in a
-   * more recent scala version so we will revisit this soon.
    */
+  @varargs
   def apply[A](as: A*): AsyncStream[A] = fromSeq(as)
 
   /**

--- a/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
@@ -1,9 +1,7 @@
 package com.twitter.concurrent
 
 import com.twitter.util.{Await, Duration, Future, Return, Throw, ConstFuture}
-import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable
-import scala.collection.Seq
 import scala.language.implicitConversions
 import java.io.EOFException
 
@@ -262,11 +260,11 @@ sealed trait Spool[+A] {
    * satisfied when the entire result is ready.
    */
   def toSeq: Future[Seq[A]] = {
-    val as = new ArrayBuffer[A]
+    val as = Vector.newBuilder[A]
     foreach { a =>
       as += a
     } map { _ =>
-      as
+      as.result
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
@@ -3,6 +3,7 @@ package com.twitter.concurrent
 import com.twitter.util.{Await, Duration, Future, Return, Throw, ConstFuture}
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable
+import scala.collection.Seq
 import scala.language.implicitConversions
 import java.io.EOFException
 
@@ -281,7 +282,11 @@ sealed trait Spool[+A] {
 /**
  * Abstract `Spool` class for Java compatibility.
  */
-abstract class AbstractSpool[A] extends Spool[A]
+abstract class AbstractSpool[A] extends Spool[A] {
+  //overrides work around https://github.com/scala/bug/issues/11484
+  override def ++[B >: A](that: => Spool[B]): Spool[B] = super.++(that)
+  override def ++[B >: A](that: => Future[Spool[B]]): Future[Spool[B]] = super.++(that)
+}
 
 /**
  * Note: [[Spool]] is no longer the recommended asynchronous stream abstraction.

--- a/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/Spool.scala
@@ -280,11 +280,7 @@ sealed trait Spool[+A] {
 /**
  * Abstract `Spool` class for Java compatibility.
  */
-abstract class AbstractSpool[A] extends Spool[A] {
-  //overrides work around https://github.com/scala/bug/issues/11484
-  override def ++[B >: A](that: => Spool[B]): Spool[B] = super.++(that)
-  override def ++[B >: A](that: => Future[Spool[B]]): Future[Spool[B]] = super.++(that)
-}
+abstract class AbstractSpool[A] extends Spool[A]
 
 /**
  * Note: [[Spool]] is no longer the recommended asynchronous stream abstraction.

--- a/util-core/src/main/scala/com/twitter/io/Reader.scala
+++ b/util-core/src/main/scala/com/twitter/io/Reader.scala
@@ -6,7 +6,6 @@ import com.twitter.util._
 import java.io.{File, FileInputStream, InputStream}
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
-import scala.collection.Seq
 
 /**
  * A reader exposes a pull-based API to model a potentially infinite stream of arbitrary elements.
@@ -163,8 +162,8 @@ object Reader {
     require(chunkSize > 0, s"chunkSize should be > 0 but was $chunkSize")
 
     @tailrec
-    private def loop(acc: Seq[Buf], in: Buf): Seq[Buf] = {
-      if (in.length < chunkSize) acc :+ in
+    private def loop(acc: ListBuffer[Buf], in: Buf): Seq[Buf] = {
+      if (in.length < chunkSize) (acc :+ in).toSeq
       else {
         loop(
           acc :+ in.slice(0, chunkSize),

--- a/util-core/src/main/scala/com/twitter/io/Reader.scala
+++ b/util-core/src/main/scala/com/twitter/io/Reader.scala
@@ -6,6 +6,7 @@ import com.twitter.util._
 import java.io.{File, FileInputStream, InputStream}
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
+import scala.collection.Seq
 
 /**
  * A reader exposes a pull-based API to model a potentially infinite stream of arbitrary elements.

--- a/util-core/src/main/scala/com/twitter/io/SeqReader.scala
+++ b/util-core/src/main/scala/com/twitter/io/SeqReader.scala
@@ -2,6 +2,7 @@ package com.twitter.io
 
 import com.twitter.io.SeqReader._
 import com.twitter.util.{Future, Promise}
+import scala.collection.Seq
 
 /**
  * We want to ensure that this reader always satisfies these invariants:

--- a/util-core/src/main/scala/com/twitter/util/Awaitable.scala
+++ b/util-core/src/main/scala/com/twitter/util/Awaitable.scala
@@ -2,8 +2,10 @@ package com.twitter.util
 
 import com.twitter.concurrent.Scheduler
 import java.util.concurrent.atomic.AtomicBoolean
+import scala.annotation.varargs
 import scala.collection.JavaConverters._
 import scala.util.control.{NonFatal => NF}
+
 
 /**
  * Wait for the result of some action. Awaitable is not used
@@ -160,7 +162,7 @@ object Await {
   /** $all */
   @throws(classOf[TimeoutException])
   @throws(classOf[InterruptedException])
-  @scala.annotation.varargs
+  @varargs
   def all(awaitables: Awaitable[_]*): Unit =
     all(awaitables, Duration.Top)
 

--- a/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -5,6 +5,7 @@ import java.util.logging.Logger
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.Seq
 
 /**
  * A "batcher" that takes a function `Seq[In] => Future[Seq[Out]]` and
@@ -118,7 +119,7 @@ private[util] class BatchExecutor[In, Out](
   def flushBatch(): () => Unit = {
     // this must be executed within a `synchronized` block.
     val prevBatch = new mutable.ArrayBuffer[(In, Promise[Out])](buf.length)
-    buf.copyToBuffer(prevBatch)
+    prevBatch ++= buf
     buf.clear()
 
     scheduled foreach { _.cancel() }

--- a/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -5,7 +5,7 @@ import java.util.logging.Logger
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.Seq
+import scala.collection.Iterable
 
 /**
  * A "batcher" that takes a function `Seq[In] => Future[Seq[Out]]` and
@@ -31,7 +31,7 @@ private[util] class BatchExecutor[In, Out](
   sizeThreshold: Int,
   timeThreshold: Duration = Duration.Top,
   sizePercentile: => Float = 1.0f,
-  f: Seq[In] => Future[Seq[Out]]
+  f: Iterable[In] => Future[Seq[Out]]
 )(
   implicit timer: Timer)
     extends Function1[In, Future[Out]] { batcher =>
@@ -135,7 +135,7 @@ private[util] class BatchExecutor[In, Out](
       }
   }
 
-  def executeBatch(batch: Seq[(In, Promise[Out])]): Unit = {
+  def executeBatch(batch: Iterable[(In, Promise[Out])]): Unit = {
     val uncancelled = batch filter {
       case (in, p) =>
         p.isInterrupted match {

--- a/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/util-core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -136,7 +136,7 @@ private[util] class BatchExecutor[In, Out](
   }
 
   def executeBatch(batch: Iterable[(In, Promise[Out])]): Unit = {
-    val uncancelled = batch filter {
+    val uncancelled = batch.filter {
       case (in, p) =>
         p.isInterrupted match {
           case Some(_cause) =>

--- a/util-core/src/main/scala/com/twitter/util/BoundedStack.scala
+++ b/util-core/src/main/scala/com/twitter/util/BoundedStack.scala
@@ -1,6 +1,7 @@
 package com.twitter.util
 
 import scala.reflect.ClassTag
+import scala.collection.Seq
 
 /**
  * A "stack" with a bounded size.  If you push a new element on the top
@@ -11,8 +12,8 @@ class BoundedStack[A: ClassTag](val maxSize: Int) extends Seq[A] {
   private var top = 0
   private var count_ = 0
 
-  def length: Int = count_
-  override def size: Int = count_
+  override def length: Int = count_
+  
 
   def clear(): Unit = {
     top = 0

--- a/util-core/src/main/scala/com/twitter/util/Closable.scala
+++ b/util-core/src/main/scala/com/twitter/util/Closable.scala
@@ -103,6 +103,7 @@ object Closable {
    * @note as with all `Closables`, the `deadline` passed to `close`
    *       is advisory.
    */
+  @varargs
   def sequence(closables: Closable*): Closable = new Closable {
     private final def closeSeq(
       deadline: Time,

--- a/util-core/src/main/scala/com/twitter/util/Config.scala
+++ b/util-core/src/main/scala/com/twitter/util/Config.scala
@@ -140,10 +140,10 @@ trait Config[T] extends (() => T) {
         val syntheticTermNames: Set[String] = {
           val configSymbol = mirror.reflect(config).symbol
           val configMembers = configSymbol.toType.members
-          configMembers.collect {
+          configMembers.iterator.collect {
             case symbol if symbol.isTerm && symbol.isSynthetic =>
               symbol.name.decodedName.toString
-          }(scala.collection.breakOut)
+          }.toSet
         }
         for (method <- nullaryMethods) {
           val name = method.getName

--- a/util-core/src/main/scala/com/twitter/util/Diff.scala
+++ b/util-core/src/main/scala/com/twitter/util/Diff.scala
@@ -86,7 +86,7 @@ object Diffable {
     }
 
     def map[U](f: T => U): SeqDiff[U] =
-      SeqDiff(limit, insert.mapValues(f).toMap)
+      SeqDiff(limit, insert.map {case (k, v) => (k, f(v))})
   }
 
   implicit val ofSet: Diffable[Set] = new Diffable[Set] {

--- a/util-core/src/main/scala/com/twitter/util/Diff.scala
+++ b/util-core/src/main/scala/com/twitter/util/Diff.scala
@@ -86,7 +86,7 @@ object Diffable {
     }
 
     def map[U](f: T => U): SeqDiff[U] =
-      SeqDiff(limit, insert.mapValues(f))
+      SeqDiff(limit, insert.mapValues(f).toMap)
   }
 
   implicit val ofSet: Diffable[Set] = new Diffable[Set] {

--- a/util-core/src/main/scala/com/twitter/util/Event.scala
+++ b/util-core/src/main/scala/com/twitter/util/Event.scala
@@ -3,7 +3,7 @@ package com.twitter.util
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import scala.annotation.tailrec
-import scala.collection.generic.CanBuild
+import scala.collection.compat._
 import scala.collection.immutable.Queue
 import scala.language.higherKinds
 
@@ -308,9 +308,9 @@ trait Event[+T] { self =>
    * builder. A value containing the current version of the collection
    * is notified for each incoming event.
    */
-  def build[U >: T, That](implicit cbf: CanBuild[U, That]): Event[That] = new Event[That] {
+  def build[U >: T, That](implicit factory: Factory[U, That]): Event[That] = new Event[That] {
     def register(s: Witness[That]): Closable = {
-      val b = cbf()
+      val b = factory.newBuilder
       self.respond { t =>
         b += t
         s.notify(b.result())

--- a/util-core/src/main/scala/com/twitter/util/Event.scala
+++ b/util-core/src/main/scala/com/twitter/util/Event.scala
@@ -304,11 +304,11 @@ trait Event[+T] { self =>
   }
 
   /**
-   * Progressively build a collection of events using the passed-in
+   * Progressively build any collection of events using the passed-in
    * builder. A value containing the current version of the collection
    * is notified for each incoming event.
    */
-  def build[U >: T, That](implicit factory: Factory[U, That]): Event[That] = new Event[That] {
+  def buildAny[That](implicit factory: Factory[T, That]): Event[That] = new Event[That] {
     def register(s: Witness[That]): Closable = {
       val b = factory.newBuilder
       self.respond { t =>
@@ -317,6 +317,13 @@ trait Event[+T] { self =>
       }
     }
   }
+
+  /**
+   * Progressively build a Seq of events using the passed-in
+   * builder. A value containing the current version of the collection
+   * is notified for each incoming event.
+   */
+  def build[U >: T, That <: Seq[U]](implicit factory: Factory[U, That]): Event[That] = buildAny(factory)
 
   /**
    * A Future which is satisfied by the first value observed.

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -1422,12 +1422,12 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)).map { _ => (%s) }""".format(
     sizeThreshold: Int,
     timeThreshold: Duration = Duration.Top,
     sizePercentile: => Float = 1.0f
-  )(f: Iterable[In] => Future[Seq[Out]]
+  )(f: scala.collection.Seq[In] => Future[Seq[Out]]
   )(
     implicit timer: Timer
   ): Batcher[In, Out] = {
     new Batcher[In, Out](
-      new BatchExecutor[In, Out](sizeThreshold, timeThreshold, sizePercentile, f)
+      new BatchExecutor[In, Out](sizeThreshold, timeThreshold, sizePercentile, f.compose(it => it.toSeq))
     )
   }
 }

--- a/util-core/src/main/scala/com/twitter/util/Future.scala
+++ b/util-core/src/main/scala/com/twitter/util/Future.scala
@@ -308,7 +308,7 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)).map { _ => (%s) }""".format(
 
   meths foreach println
   '
-   */
+   """*/
 
   /**
    * Join 2 futures. The returned future is complete when all

--- a/util-core/src/main/scala/com/twitter/util/FuturePool.scala
+++ b/util-core/src/main/scala/com/twitter/util/FuturePool.scala
@@ -4,6 +4,7 @@ import com.twitter.concurrent.NamedPoolThreadFactory
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent._
 import scala.runtime.NonLocalReturnControl
+import com.twitter.util.Future
 
 /**
  * A `FuturePool` executes tasks asynchronously, typically using a pool

--- a/util-core/src/main/scala/com/twitter/util/Futures.scala
+++ b/util-core/src/main/scala/com/twitter/util/Futures.scala
@@ -1,6 +1,7 @@
 package com.twitter.util
 
 import java.util.{List => JList, Map => JMap}
+import scala.collection.Iterable
 import scala.collection.JavaConverters.{
   asScalaBufferConverter,
   mapAsJavaMapConverter,
@@ -776,7 +777,7 @@ def join[%s](%s): Future[(%s)] = join(Seq(%s)).map { _ => (%s) }""".format(
    * to be satisfied and the rest of the futures.
    */
   def select[A](fs: JList[Future[A]]): Future[(Try[A], JList[Future[A]])] =
-    Future.select(fs.asScala).map {
+    Future.select(fs.asScala.toSeq).map {
       case (first, rest) =>
         (first, rest.asJava)
     }

--- a/util-core/src/main/scala/com/twitter/util/Pool.scala
+++ b/util-core/src/main/scala/com/twitter/util/Pool.scala
@@ -1,7 +1,7 @@
 package com.twitter.util
 
 import scala.collection.mutable
-import scala.collection.Seq
+import scala.collection.Iterable
 
 trait Pool[A] {
   def reserve(): Future[A]
@@ -9,7 +9,7 @@ trait Pool[A] {
 }
 
 class SimplePool[A](items: mutable.Queue[Future[A]]) extends Pool[A] {
-  def this(initialItems: Seq[A]) = this {
+  def this(initialItems: Iterable[A]) = this {
     val queue = new mutable.Queue[Future[A]]
     queue ++= initialItems.map(Future(_))
     queue

--- a/util-core/src/main/scala/com/twitter/util/Pool.scala
+++ b/util-core/src/main/scala/com/twitter/util/Pool.scala
@@ -1,6 +1,7 @@
 package com.twitter.util
 
 import scala.collection.mutable
+import scala.collection.Seq
 
 trait Pool[A] {
   def reserve(): Future[A]
@@ -54,38 +55,4 @@ abstract class FactoryPool[A](numItems: Int) extends Pool[A] {
   protected def isHealthy(a: A): Boolean
 }
 
-private class HealthyQueue[A](makeItem: () => Future[A], numItems: Int, isHealthy: A => Boolean)
-    extends mutable.Queue[Future[A]] {
 
-  0.until(numItems) foreach { _ =>
-    this += makeItem()
-  }
-
-  override def +=(elem: Future[A]): HealthyQueue.this.type = synchronized {
-    super.+=(elem)
-  }
-
-  override def +=:(elem: Future[A]): HealthyQueue.this.type = synchronized {
-    super.+=:(elem)
-  }
-
-  override def enqueue(elems: Future[A]*): Unit = synchronized {
-    super.enqueue(elems: _*)
-  }
-
-  override def dequeue(): Future[A] = synchronized {
-    if (isEmpty) throw new NoSuchElementException("queue empty")
-
-    super.dequeue() flatMap { item =>
-      if (isHealthy(item)) {
-        Future(item)
-      } else {
-        val item = makeItem()
-        synchronized {
-          enqueue(item)
-          dequeue()
-        }
-      }
-    }
-  }
-}

--- a/util-core/src/main/scala/com/twitter/util/StorageUnit.scala
+++ b/util-core/src/main/scala/com/twitter/util/StorageUnit.scala
@@ -126,7 +126,7 @@ class StorageUnit(val bytes: Long) extends Ordered[StorageUnit] {
   def max(other: StorageUnit): StorageUnit =
     if (this > other) this else other
 
-  override def toString(): String = inBytes + ".bytes"
+  override def toString(): String = inBytes.toString + ".bytes"
 
   def toHuman(): String = {
     val prefix = "KMGTPE"

--- a/util-core/src/main/scala/com/twitter/util/StorageUnit.scala
+++ b/util-core/src/main/scala/com/twitter/util/StorageUnit.scala
@@ -126,7 +126,7 @@ class StorageUnit(val bytes: Long) extends Ordered[StorageUnit] {
   def max(other: StorageUnit): StorageUnit =
     if (this > other) this else other
 
-  override def toString(): String = inBytes.toString + ".bytes"
+  override def toString(): String = s"$inBytes bytes"
 
   def toHuman(): String = {
     val prefix = "KMGTPE"

--- a/util-core/src/main/scala/com/twitter/util/Throwables.scala
+++ b/util-core/src/main/scala/com/twitter/util/Throwables.scala
@@ -2,6 +2,7 @@ package com.twitter.util
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.Seq
 
 object Throwables {
 

--- a/util-core/src/main/scala/com/twitter/util/Throwables.scala
+++ b/util-core/src/main/scala/com/twitter/util/Throwables.scala
@@ -2,7 +2,6 @@ package com.twitter.util
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.Seq
 
 object Throwables {
 
@@ -28,14 +27,14 @@ object Throwables {
    * classname strings.
    */
   def mkString(ex: Throwable): Seq[String] = {
-    @tailrec def rec(ex: Throwable, buf: ArrayBuffer[String]): Seq[String] = {
+    @tailrec def rec(ex: Throwable, buf: List[String]): Seq[String] = {
       if (ex eq null)
-        buf.result
+        buf.reverse
       else
-        rec(ex.getCause, buf += ex.getClass.getName)
+        rec(ex.getCause, ex.getClass.getName :: buf)
     }
 
-    rec(ex, ArrayBuffer.empty)
+    rec(ex, Nil)
   }
 
   object RootCause {

--- a/util-core/src/main/scala/com/twitter/util/Timer.scala
+++ b/util-core/src/main/scala/com/twitter/util/Timer.scala
@@ -4,6 +4,7 @@ import com.twitter.concurrent.NamedPoolThreadFactory
 import java.util.concurrent._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control
+import com.twitter.util.Future
 
 /**
  * TimerTasks represent pending tasks scheduled by a [[Timer]].

--- a/util-core/src/main/scala/com/twitter/util/Var.scala
+++ b/util-core/src/main/scala/com/twitter/util/Var.scala
@@ -369,13 +369,10 @@ object Var {
         if (!filling) v() = build()
       }
 
-      val closes = new Array[Closable](N)
-      var i = 0
-      for (v <- vars) {
-        val j = i
-        closes(j) = v.observe(0, Observer(newValue => publish(j, newValue)))
-        i += 1
-      }
+      val closes = vars.iterator
+                       .zipWithIndex
+                       .map{ case (v, i) => v.observe(0, Observer(newValue => publish(i, newValue)))}
+                       .toSeq
 
       filling = false
       v() = build()

--- a/util-core/src/main/scala/com/twitter/util/Var.scala
+++ b/util-core/src/main/scala/com/twitter/util/Var.scala
@@ -3,12 +3,13 @@ package com.twitter.util
 import java.util.concurrent.atomic.{AtomicLong, AtomicReference, AtomicReferenceArray}
 import java.util.{List => JList}
 import scala.annotation.tailrec
+import scala.collection.compat._
 import scala.collection.JavaConverters._
-import scala.collection.generic.CanBuildFrom
 import scala.collection.immutable
 import scala.collection.mutable.Buffer
 import scala.language.higherKinds
 import scala.reflect.ClassTag
+import scala.Iterable
 
 /**
  * Vars are values that vary over time. To create one, you must give it an
@@ -296,10 +297,10 @@ object Var {
    *  // refCollectIndependent == Vector((1,2), (2,2), (2,4))
    * }}}
    */
-  def collect[T: ClassTag, CC[X] <: Traversable[X]](
+  def collect[T: ClassTag, CC[X] <: Iterable[X]](
     vars: CC[Var[T]]
   )(
-    implicit newBuilder: CanBuildFrom[CC[T], T, CC[T]]
+    implicit factory: Factory[T, CC[T]]
   ): Var[CC[T]] = {
     val vs = vars.toArray
 
@@ -316,7 +317,7 @@ object Var {
       }
 
     tree(0, vs.length).map { ts =>
-      val b = newBuilder()
+      val b = factory.newBuilder
       b ++= ts
       b.result()
     }
@@ -344,17 +345,17 @@ object Var {
    *  // refCollectIndependent == Vector((1,2), (2,2), (2,4))
    * }}}
    */
-  def collectIndependent[T: ClassTag, CC[X] <: Traversable[X]](
+  def collectIndependent[T: ClassTag, CC[X] <: Iterable[X]](
     vars: CC[Var[T]]
   )(
-    implicit newBuilder: CanBuildFrom[CC[T], T, CC[T]]
+    implicit factory: Factory[T, CC[T]]
   ): Var[CC[T]] =
-    async(newBuilder().result()) { v =>
+    async(factory.newBuilder.result()) { v =>
       val N = vars.size
       val cur = new AtomicReferenceArray[T](N)
       @volatile var filling = true
       def build() = {
-        val b = newBuilder()
+        val b = factory.newBuilder
         var i = 0
         while (i < N) {
           b += cur.get(i)

--- a/util-core/src/test/java/com/twitter/concurrent/SpoolCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/concurrent/SpoolCompilationTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class SpoolCompilationTest {
-
   private static class OwnSpool extends AbstractSpool<String> {
     @Override
     public boolean isEmpty() {
@@ -26,8 +25,7 @@ public class SpoolCompilationTest {
     public String head() {
       return "spool";
     }
-  }
-  
+  }  
   @Test
   public void testOwnSpool() {
     Spool<String> a = new OwnSpool();
@@ -64,5 +62,4 @@ public class SpoolCompilationTest {
     Assert.assertArrayEquals(new String[] { "a", "b"}, listB.toArray());
     Assert.assertArrayEquals(new String[] { "a", "b", "c" , "d"}, listC.toArray());
   }
-  
 }

--- a/util-core/src/test/java/com/twitter/concurrent/SpoolCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/concurrent/SpoolCompilationTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class SpoolCompilationTest {
+
   private static class OwnSpool extends AbstractSpool<String> {
     @Override
     public boolean isEmpty() {
@@ -26,7 +27,7 @@ public class SpoolCompilationTest {
       return "spool";
     }
   }
-
+  
   @Test
   public void testOwnSpool() {
     Spool<String> a = new OwnSpool();
@@ -63,4 +64,5 @@ public class SpoolCompilationTest {
     Assert.assertArrayEquals(new String[] { "a", "b"}, listB.toArray());
     Assert.assertArrayEquals(new String[] { "a", "b", "c" , "d"}, listC.toArray());
   }
+  
 }

--- a/util-core/src/test/java/com/twitter/io/BufCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/io/BufCompilationTest.java
@@ -3,7 +3,7 @@ package com.twitter.io;
 import org.junit.Assert;
 import org.junit.Test;
 import scala.Option;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -55,7 +55,7 @@ public class BufCompilationTest {
     Buf abc = Bufs.utf8Buf("abc");
     Buf def = Bufs.utf8Buf("def");
     Buf merged = Buf.apply(
-      JavaConversions.asScalaBuffer(Arrays.asList(empty, abc, def)));
+      JavaConverters.asScalaBuffer(Arrays.asList(empty, abc, def)));
   }
 
   @Test

--- a/util-core/src/test/java/com/twitter/io/BufCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/io/BufCompilationTest.java
@@ -55,7 +55,8 @@ public class BufCompilationTest {
     Buf abc = Bufs.utf8Buf("abc");
     Buf def = Bufs.utf8Buf("def");
     Buf merged = Buf.apply(
-      JavaConverters.asScalaBuffer(Arrays.asList(empty, abc, def)));
+      JavaConverters.asScalaBufferConverter(Arrays.asList(empty, abc, def)).asScala()
+    );
   }
 
   @Test

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncSemaphoreTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncSemaphoreTest.scala
@@ -268,11 +268,11 @@ class AsyncSemaphoreTest extends FunSpec {
       assert(counter == 2)
       assert(semHelper.sem.numPermitsAvailable == 0)
 
-      queue.dequeue().setValue(Unit)
+      queue.dequeue().setValue(())
       assert(counter == 3)
       assert(semHelper.sem.numPermitsAvailable == 0)
 
-      queue.dequeue().setValue(Unit)
+      queue.dequeue().setValue(())
       assert(semHelper.sem.numPermitsAvailable == 1)
 
       queue.dequeue().setException(new RuntimeException("test"))
@@ -320,7 +320,7 @@ class AsyncSemaphoreTest extends FunSpec {
       // sync func is blocked at this point.
       // But it should be executed as soon as one of the queued up future functions finish
 
-      queue.dequeue().setValue(Unit)
+      queue.dequeue().setValue(())
       assert(counter == 3)
       val result = Await.result(future)
       assert(result == 3)
@@ -359,7 +359,7 @@ class AsyncSemaphoreTest extends FunSpec {
       // sync func is blocked at this point.
       // But it should be executed as soon as one of the queued up future functions finish
 
-      queue.dequeue().setValue(Unit)
+      queue.dequeue().setValue(())
       assert(counter == 2)
       assert(Try(Await.result(future)).isThrow)
       assert(semHelper.sem.numPermitsAvailable == 1)

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -386,14 +386,12 @@ class AsyncStreamTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
       }
     }
 
-    test(s"$impl: buffer() works like Seq.splitAt for positive values") {
+    test(s"$impl: buffer() works like Seq.splitAt") {
       forAll { (items: List[Char], bufferSize: Int) => 
-        if (bufferSize >= 0) {
-          val (expectedBuffer, expectedRest) = items.splitAt(bufferSize)
-          val (buffer, rest) = await(fromSeq(items).buffer(bufferSize))
-          assert(expectedBuffer == buffer)
-          assert(expectedRest == toSeq(rest()))
-        }
+        val (expectedBuffer, expectedRest) = items.splitAt(bufferSize)
+        val (buffer, rest) = await(fromSeq(items).buffer(bufferSize))
+        assert(expectedBuffer == buffer)
+        assert(expectedRest == toSeq(rest()))
       }
     }
 
@@ -403,7 +401,7 @@ class AsyncStreamTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
       val gen = Gen.zip(Gen.nonEmptyListOf(Arbitrary.arbitrary[Char]), Arbitrary.arbitrary[Int])
 
       forAll(gen) {
-        case (items, n) if n >= 0 =>
+        case (items, n) =>
           var forced1 = false
           val stream1 = fromSeq(items) ++ { forced1 = true; AsyncStream.empty[Char] }
           var forced2 = false
@@ -436,8 +434,6 @@ class AsyncStreamTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
           assert(toSeq(bufferTail) == toSeq(dropTail))
           assert(forced1)
           assert(forced2)
-        
-        case _ => ()
       }
     }
 

--- a/util-core/src/test/scala/com/twitter/concurrent/OfferTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/OfferTest.scala
@@ -4,8 +4,7 @@ import scala.util.Random
 
 import org.mockito.Mockito._
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
-
+import org.scalatestplus.mockito.MockitoSugar
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, MockTimer, Promise, Return, Time}
 

--- a/util-core/src/test/scala/com/twitter/concurrent/SpoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SpoolTest.scala
@@ -6,10 +6,10 @@ import com.twitter.util.{Await, Future, Promise, Return, Throw}
 import java.io.EOFException
 import org.scalacheck.Arbitrary
 import org.scalatest.WordSpec
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable.ArrayBuffer
 
-class SpoolTest extends WordSpec with GeneratorDrivenPropertyChecks {
+class SpoolTest extends WordSpec with ScalaCheckDrivenPropertyChecks {
   "Empty Spool" should {
     val s = Spool.empty[Int]
 

--- a/util-core/src/test/scala/com/twitter/conversions/PercentOpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/PercentOpsTest.scala
@@ -4,9 +4,9 @@ import com.twitter.conversions.PercentOps._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class PercentOpsTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class PercentOpsTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private[this] val Precision = 0.0000000001
 

--- a/util-core/src/test/scala/com/twitter/conversions/U64OpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/U64OpsTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.conversions
 
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class U64OpsTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class U64OpsTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import com.twitter.conversions.U64Ops._
 
   test("toU64HextString") {

--- a/util-core/src/test/scala/com/twitter/io/BufByteWriterTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufByteWriterTest.scala
@@ -3,9 +3,9 @@ package com.twitter.io
 import java.lang.{Double => JDouble, Float => JFloat}
 import java.nio.charset.StandardCharsets
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-final class BufByteWriterTest extends FunSuite with GeneratorDrivenPropertyChecks {
+final class BufByteWriterTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import ByteWriter.OverflowException
 
   private[this] def assertIndex(bw: ByteWriter, index: Int): Unit = bw match {

--- a/util-core/src/test/scala/com/twitter/io/BufReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufReaderTest.scala
@@ -3,7 +3,7 @@ package com.twitter.io
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future}
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class BufReaderTest extends FunSuite with Checkers {
 

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -6,7 +6,7 @@ import java.nio.charset.{StandardCharsets => JChar}
 import java.util.Arrays
 import org.scalacheck.{Arbitrary, Gen, Prop}
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatestplus.scalacheck.Checkers

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -107,7 +107,7 @@ class BufTest
   test("Buf.equals") {
     val bytes = Array[Byte](0, 1, 2)
     val byteBuffer = Buf.ByteBuffer.Owned(java.nio.ByteBuffer.wrap(bytes))
-    val byteArray = Buf.ByteArray(bytes: _*)
+    val byteArray = Buf.ByteArray(bytes.toSeq: _*)
     val composite = Buf.ByteArray(0).concat(Buf.ByteArray(1)).concat(Buf.ByteArray(2))
     val bufs = Seq(byteBuffer, byteArray, composite)
 

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -7,15 +7,16 @@ import java.util.Arrays
 import org.scalacheck.{Arbitrary, Gen, Prop}
 import org.scalatest.FunSuite
 import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatestplus.scalacheck.Checkers
 import scala.collection.mutable
 import java.nio.charset.Charset
 
 class BufTest
     extends FunSuite
     with MockitoSugar
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with Checkers
     with AssertionsForJUnit {
 

--- a/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
@@ -4,9 +4,9 @@ import java.lang.{Double => JDouble, Float => JFloat}
 import java.nio.charset.StandardCharsets
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ByteReaderTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ByteReaderTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import ByteReader._
 
   def readerWith(bytes: Byte*): ByteReader = ByteReader(Buf.ByteArray.Owned(bytes.toArray))
@@ -167,12 +167,12 @@ class ByteReaderTest extends FunSuite with GeneratorDrivenPropertyChecks {
 
   test("readUnsignedIntBE")(forAll { i: Int =>
     val br = new ByteReaderImpl(Buf.Empty) { override def readIntBE() = i }
-    assert(br.readUnsignedIntBE() == (i & 0xffffffffl))
+    assert(br.readUnsignedIntBE() == (i & 0xffffffffL))
   })
 
   test("readUnsignedIntLE")(forAll { i: Int =>
     val br = new ByteReaderImpl(Buf.Empty) { override def readIntLE() = i }
-    assert(br.readUnsignedIntLE() == (i & 0xffffffffl))
+    assert(br.readUnsignedIntLE() == (i & 0xffffffffL))
   })
 
   val uInt64s: Gen[BigInt] = Gen

--- a/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
@@ -29,7 +29,7 @@ class ByteReaderTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   test("readString")(forAll { (str1: String, str2: String) =>
     val bytes1 = str1.getBytes(StandardCharsets.UTF_8)
     val bytes2 = str2.getBytes(StandardCharsets.UTF_8)
-    val br = readerWith(bytes1 ++ bytes2: _*)
+    val br = readerWith((bytes1 ++ bytes2).toSeq: _*)
     assert(br.readString(bytes1.length, StandardCharsets.UTF_8) == str1)
     assert(br.readString(bytes2.length, StandardCharsets.UTF_8) == str2)
     intercept[UnderflowException] { br.readByte() }

--- a/util-core/src/test/scala/com/twitter/io/PipeTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/PipeTest.scala
@@ -141,19 +141,20 @@ class PipeTest extends FunSuite with Matchers {
     assert(closed)
   }
 
-  test("write then reads then close") {
+  test("write then reads then close") { testWriteReadClose }
+  def testWriteReadClose = {
     val rw = new Pipe[Buf]
     val wf = rw.write(buf(0, 6))
 
     assert(!wf.isDone)
     assertRead(rw, 0, 6)
     assert(wf.isDone)
-
     assert(!rw.close().isDone)
     assertReadEofAndClosed(rw)
   }
 
-  test("read then write then close") {
+  test("read then write then close") { readWriteClose }
+  def readWriteClose = {
     val rw = new Pipe[Buf]
 
     val rf = rw.read()
@@ -213,13 +214,16 @@ class PipeTest extends FunSuite with Matchers {
     assertFailedEx(rw.read())
   }
 
-  test("read after close with no pending reads") {
+  def readAfterCloseNoPendingReads = {
     val rw = new Pipe[Buf]
     assert(!rw.close().isDone)
     assertReadEofAndClosed(rw)
   }
+  test("read after close with no pending reads") {
+    readAfterCloseNoPendingReads
+  }
 
-  test("read after close with pending data") {
+  def readAfterClosePendingData = {
     val rw = new Pipe[Buf]
 
     val wf = rw.write(buf(0, 1))
@@ -235,6 +239,7 @@ class PipeTest extends FunSuite with Matchers {
       await(rw.onClose)
     }
   }
+  test("read after close with pending data") { readAfterClosePendingData }
 
   test("read while reading") {
     val rw = new Pipe[Buf]
@@ -280,7 +285,7 @@ class PipeTest extends FunSuite with Matchers {
     assertReadEofAndClosed(rw)
   }
 
-  test("close not satisfied until reads are fulfilled") {
+  def closeNotSatisfiedUntillAllReadsDone = {
     val rw = new Pipe[Buf]
     val rf = rw.read()
     val cf = rf.flatMap { _ =>
@@ -295,8 +300,9 @@ class PipeTest extends FunSuite with Matchers {
     assert(!cf.isDone)
     assertReadEofAndClosed(rw)
   }
+  test("close not satisfied until reads are fulfilled")(closeNotSatisfiedUntillAllReadsDone)
 
-  test("close while read pending") {
+  def closeWhileReadPending = {
     val rw = new Pipe[Buf]
     val rf = rw.read()
     assert(!rf.isDefined)
@@ -304,14 +310,16 @@ class PipeTest extends FunSuite with Matchers {
     assert(rw.close().isDone)
     assert(rf.isDefined)
   }
+  test("close while read pending")(closeWhileReadPending)
 
-  test("close then close") {
+  def closeTwice = {
     val rw = new Pipe[Buf]
     assert(!rw.close().isDone)
     assertReadEofAndClosed(rw)
     assert(rw.close().isDone)
     assertReadEofAndClosed(rw)
   }
+  test("close then close")(closeTwice)
 
   test("close after fail") {
     val rw = new Pipe[Buf]
@@ -432,4 +440,5 @@ class PipeTest extends FunSuite with Matchers {
       assertReadEofAndClosed(rw)
     }
   }
+
 }

--- a/util-core/src/test/scala/com/twitter/io/ReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ReaderTest.scala
@@ -10,14 +10,14 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.mockito.Mockito._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FunSuite, Matchers}
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
 class ReaderTest
     extends FunSuite
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with Matchers
     with Eventually
     with IntegrationPatience {

--- a/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
@@ -3,8 +3,6 @@ package com.twitter.util
 import java.util.concurrent.atomic.AtomicReference
 import org.scalatest.FunSuite
 import scala.collection.compat._
-import scala.collection.Seq
-import scala.collection.Seq._
 
 class ActivityTest extends FunSuite {
   test("Activity#flatMap") {

--- a/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
@@ -2,6 +2,9 @@ package com.twitter.util
 
 import java.util.concurrent.atomic.AtomicReference
 import org.scalatest.FunSuite
+import scala.collection.compat._
+import scala.collection.Seq
+import scala.collection.Seq._
 
 class ActivityTest extends FunSuite {
   test("Activity#flatMap") {

--- a/util-core/src/test/scala/com/twitter/util/Base64LongTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/Base64LongTest.scala
@@ -5,7 +5,7 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 object Base64LongTest {
   private val BoundaryValues =
@@ -52,7 +52,7 @@ object Base64LongTest {
   }
 }
 
-class Base64LongTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class Base64LongTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import Base64LongTest._
 
   private[this] def forAllLongs(f: (Alphabet, Long) => Unit): Unit = {

--- a/util-core/src/test/scala/com/twitter/util/CredentialsTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/CredentialsTest.scala
@@ -17,12 +17,13 @@
 package com.twitter.util
 
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class CredentialsTest extends FunSuite with Checkers {
   test("parse a simple auth file") {
     val content = "username: root\npassword: hellokitty\n"
-    assert(Credentials(content) == Map("username" -> "root", "password" -> "hellokitty"))
+    val result = Credentials(content)
+    assert(result == Map("username" -> "root", "password" -> "hellokitty"))
   }
 
   test("parse a more complex auth file") {

--- a/util-core/src/test/scala/com/twitter/util/DiffTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DiffTest.scala
@@ -2,9 +2,9 @@ package com.twitter.util
 
 import org.scalatest.FunSuite
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class DiffTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class DiffTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   val f: Int => String = _.toString
 
   test("Diffable.ofSet") {

--- a/util-core/src/test/scala/com/twitter/util/EventTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/EventTest.scala
@@ -4,8 +4,7 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{CountDownLatch, Executors}
 import org.scalatest.FunSuite
 import scala.collection.mutable
-import scala.collection.Seq
-import scala.collection.Seq._
+import scala.collection.compat._
 
 class EventTest extends FunSuite {
 
@@ -329,9 +328,7 @@ class EventTest extends FunSuite {
 
   test("Event.dedupWith") {
     val e = Event[Int]()
-    val ref = new AtomicReference[IndexedSeq[Int]]
-    import IndexedSeq._
-
+    val ref = new AtomicReference[Seq[Int]]
     e.dedupWith { (a, b) =>
         a >= b
       }
@@ -350,10 +347,8 @@ class EventTest extends FunSuite {
 
   test("Event.dedup") {
     val e = Event[Int]()
-    val ref = new AtomicReference[IndexedSeq[Int]]
-    import IndexedSeq._
-
-    e.dedup.build.register(Witness(ref))
+    val ref = new AtomicReference[Seq[Int]]
+    e.dedup.buildAny[IndexedSeq[Int]].register(Witness(ref))
     e.notify(0)
     e.notify(0)
     e.notify(1)
@@ -363,4 +358,5 @@ class EventTest extends FunSuite {
 
     assert(ref.get() == List(0, 1, 0))
   }
+
 }

--- a/util-core/src/test/scala/com/twitter/util/EventTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/EventTest.scala
@@ -4,6 +4,8 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{CountDownLatch, Executors}
 import org.scalatest.FunSuite
 import scala.collection.mutable
+import scala.collection.Seq
+import scala.collection.Seq._
 
 class EventTest extends FunSuite {
 
@@ -328,6 +330,7 @@ class EventTest extends FunSuite {
   test("Event.dedupWith") {
     val e = Event[Int]()
     val ref = new AtomicReference[IndexedSeq[Int]]
+    import IndexedSeq._
 
     e.dedupWith { (a, b) =>
         a >= b
@@ -348,6 +351,7 @@ class EventTest extends FunSuite {
   test("Event.dedup") {
     val e = Event[Int]()
     val ref = new AtomicReference[IndexedSeq[Int]]
+    import IndexedSeq._
 
     e.dedup.build.register(Witness(ref))
     e.notify(0)

--- a/util-core/src/test/scala/com/twitter/util/FutureOfferTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureOfferTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.concurrent
 
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import com.twitter.util.{Promise, Return}
 
 class FutureOfferTest extends WordSpec with MockitoSugar {

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -9,8 +9,9 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import scala.collection.Seq
 import scala.collection.JavaConverters._
 import scala.runtime.NonLocalReturnControl
 import scala.util.Random
@@ -38,7 +39,7 @@ private object FutureTest {
   }
 }
 
-class FutureTest extends WordSpec with MockitoSugar with GeneratorDrivenPropertyChecks {
+class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropertyChecks {
   import FutureTest._
 
   implicit class FutureMatcher[A](future: Future[A]) {

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -11,7 +11,6 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import scala.collection.Seq
 import scala.collection.JavaConverters._
 import scala.runtime.NonLocalReturnControl
 import scala.util.Random
@@ -264,7 +263,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         val result = Seq(4, 5, 6)
 
         "execute after threshold is reached" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3)(f)
 
           when(f.apply(Seq(1, 2, 3))).thenReturn(Future.value(result))
@@ -277,7 +276,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "execute after bufSizeFraction threshold is reached" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3, sizePercentile = 0.67f)(f)
 
           when(f.apply(Seq(1, 2, 3))).thenReturn(Future.value(result))
@@ -288,7 +287,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "treat bufSizeFraction return value < 0.0f as 1" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3, sizePercentile = 0.4f)(f)
 
           when(f.apply(Seq(1, 2, 3))).thenReturn(Future.value(result))
@@ -297,7 +296,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "treat bufSizeFraction return value > 1.0f should return maxSizeThreshold" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3, sizePercentile = 1.3f)(f)
 
           when(f.apply(Seq(1, 2, 3))).thenReturn(Future.value(result))
@@ -310,7 +309,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "execute after time threshold" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3, 3.seconds)(f)
 
           Time.withCurrentTimeFrozen { control =>
@@ -333,7 +332,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "only execute once if both are reached" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3)(f)
 
           Time.withCurrentTimeFrozen { control =>
@@ -349,7 +348,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "execute when flushBatch is called" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(4)(f)
 
           batcher(1)
@@ -361,7 +360,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "only execute for remaining items when flushBatch is called after size threshold is reached" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(4)(f)
 
           batcher(1)
@@ -376,7 +375,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "only execute once when time threshold is reached after flushBatch is called" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(4, 3.seconds)(f)
 
           Time.withCurrentTimeFrozen { control =>
@@ -392,7 +391,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "only execute once when time threshold is reached before flushBatch is called" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(4, 3.seconds)(f)
 
           Time.withCurrentTimeFrozen { control =>
@@ -408,7 +407,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "propagates results" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3)(f)
 
           Time.withCurrentTimeFrozen { _ =>
@@ -431,7 +430,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "not block other batches" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3)(f)
 
           Time.withCurrentTimeFrozen { _ =>
@@ -465,7 +464,7 @@ class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropert
         }
 
         "swallow exceptions" in {
-          val f = mock[Seq[Int] => Future[Seq[Int]]]
+          val f = mock[Iterable[Int] => Future[Seq[Int]]]
           val batcher = Future.batched(3)(f)
 
           when(f(Seq(1, 2, 3))).thenAnswer {

--- a/util-core/src/test/scala/com/twitter/util/LocalTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/LocalTest.scala
@@ -3,9 +3,9 @@ package com.twitter.util
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class LocalTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class LocalTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   test("Local: should be undefined by default") {
     val local = new Local[Int]
     assert(local() == None)

--- a/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
@@ -3,7 +3,7 @@ package com.twitter.util
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 object MonitorTest {
   class MockMonitor extends Monitor {

--- a/util-core/src/test/scala/com/twitter/util/PoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PoolTest.scala
@@ -1,12 +1,14 @@
 package com.twitter.util
 
 import scala.collection.mutable
+import scala.collection.Seq
 
 import org.scalatest.WordSpec
 
 import com.twitter.conversions.DurationOps._
 
 class PoolTest extends WordSpec {
+  
   "SimplePool" should {
     "with a simple queue of items" should {
       "it reseves items in FIFO order" in {

--- a/util-core/src/test/scala/com/twitter/util/PoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PoolTest.scala
@@ -4,7 +4,6 @@ import scala.collection.mutable
 import scala.collection.Seq
 
 import org.scalatest.WordSpec
-
 import com.twitter.conversions.DurationOps._
 
 class PoolTest extends WordSpec {

--- a/util-core/src/test/scala/com/twitter/util/TimeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimeTest.scala
@@ -6,11 +6,11 @@ import java.util.concurrent.TimeUnit
 
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import com.twitter.conversions.DurationOps._
 
-trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with GeneratorDrivenPropertyChecks {
+trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with ScalaCheckDrivenPropertyChecks {
   val ops: TimeLikeOps[T]
   import ops._
 

--- a/util-core/src/test/scala/com/twitter/util/TimerTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimerTest.scala
@@ -8,7 +8,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{IntegrationPatience, Eventually}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class TimerTest extends FunSuite with MockitoSugar with Eventually with IntegrationPatience {
 

--- a/util-core/src/test/scala/com/twitter/util/VarTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/VarTest.scala
@@ -5,8 +5,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable
-import scala.collection.Seq
-import scala.collection.Seq._
+import scala.collection.compat._
 
 class VarTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   private case class U[T](init: T) extends UpdatableVar[T](init) {
@@ -219,7 +218,7 @@ class VarTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   }
 
   test("Var.collect: empty") {
-    assert(Var.collect(Seq.empty[Var[Int]]).sample == Seq.empty)
+    assert(Var.collect(List.empty[Var[Int]]).sample == Nil)
   }
 
   test("Var.collect[Seq]") {

--- a/util-core/src/test/scala/com/twitter/util/VarTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/VarTest.scala
@@ -3,10 +3,12 @@ package com.twitter.util
 import java.util.concurrent.atomic.AtomicReference
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable
+import scala.collection.Seq
+import scala.collection.Seq._
 
-class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class VarTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   private case class U[T](init: T) extends UpdatableVar[T](init) {
     import Var.Observer
 

--- a/util-core/src/test/scala/com/twitter/util/WaitQueueTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/WaitQueueTest.scala
@@ -2,9 +2,9 @@ package com.twitter.util
 
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class WaitQueueTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class WaitQueueTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private class EmptyK[A] extends Promise.K[A] {
     protected[util] def depth: Short = 0

--- a/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.hashing
 
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class HashableTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class HashableTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private[this] val algorithms = Seq(
     Hashable.CRC32_ITU,

--- a/util-hashing/src/test/scala/com/twitter/hashing/KetamaDistributorTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/KetamaDistributorTest.scala
@@ -2,13 +2,13 @@ package com.twitter.hashing
 
 import org.scalacheck.Gen
 import org.scalatest.WordSpec
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable
 import java.io.{BufferedReader, InputStreamReader}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.security.MessageDigest
 
-class KetamaDistributorTest extends WordSpec with GeneratorDrivenPropertyChecks {
+class KetamaDistributorTest extends WordSpec with ScalaCheckDrivenPropertyChecks {
   "KetamaDistributor" should {
     val nodes = Seq(
       KetamaNode("10.0.1.1", 600, 1),
@@ -81,8 +81,7 @@ class KetamaDistributorTest extends WordSpec with GeneratorDrivenPropertyChecks 
         val md = MessageDigest.getInstance("MD5")
         ketama.hashInt(i, md)
         val array = md.digest()
-
-        assert(array.deep == md.digest(i.toString.getBytes("UTF-8")).deep)
+        assert(array.toSeq == md.digest(i.toString.getBytes("UTF-8")).toSeq)
       }
     }
 

--- a/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
@@ -206,7 +206,7 @@ class Hotspot extends Jvm {
   def tenuringThreshold: Long = counter("sun.gc.policy.tenuringThreshold").map(long).getOrElse(0L)
 
   def snapCounters: Map[String, String] =
-    counters("").mapValues(_.getValue().toString)
+    counters("").map{case (k, v) => (k -> v.getValue().toString)}
 
   def forceGc(): Unit = System.gc()
 }

--- a/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
@@ -35,7 +35,7 @@ trait Jvm {
    */
   def snap: Snapshot
 
-  def edenPool: Pool
+  def edenPool: com.twitter.jvm.Pool
 
   /**
    * Gets the current usage of the metaspace, if available.

--- a/util-jvm/src/test/scala/com/twitter/jvm/ContentionTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/ContentionTest.scala
@@ -11,7 +11,7 @@ class Philosopher {
   private val lock = new ReentrantLock()
   def dine(neighbor: Philosopher): Unit = {
     lock.lockInterruptibly()
-    ready.setValue(Unit)
+    ready.setValue(())
     Await.ready(neighbor.ready)
     neighbor.dine(this)
     lock.unlock()

--- a/util-jvm/src/test/scala/com/twitter/jvm/EstimatorApp.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/EstimatorApp.scala
@@ -20,12 +20,12 @@ object EstimatorApp extends App {
     case Array("windowed", n, windows) =>
       new WindowedMeans(
         n.toInt,
-        windows.split(",") map { w =>
+        windows.split(",").iterator.map { w =>
           w.split(":") match {
             case Array(w, i) => (w.toInt, i.toInt)
             case _ => throw new IllegalArgumentException("bad weight, count pair " + w)
           }
-        }
+        }.toSeq
       )
     case Array("load", interval) =>
       new LoadAverage(interval.toDouble)

--- a/util-jvm/src/test/scala/com/twitter/jvm/JvmTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/JvmTest.scala
@@ -60,7 +60,7 @@ class JvmTest extends WordSpec with TestLogging {
         assert(jvm.executor.schedules == List())
         jvm foreachGc { b += _ }
         assert(jvm.executor.schedules.size == 1)
-        val Seq((r, _, _, _)) = jvm.executor.schedules
+        val r = jvm.executor.schedules.head._1
         r.run()
         assert(b == List())
         val gc = Gc(0, "pcopy", Time.now, 1.millisecond)
@@ -97,7 +97,7 @@ class JvmTest extends WordSpec with TestLogging {
           jvm foreachGc { _ => /*ignore*/
           }
           assert(jvm.executor.schedules.size == 1)
-          val Seq((r, _, _, _)) = jvm.executor.schedules
+          val r = jvm.executor.schedules.head._1
           val gc = Gc(0, "pcopy", Time.now, 1.millisecond)
           r.run()
           jvm.pushGc(gc)
@@ -130,7 +130,7 @@ class JvmTest extends WordSpec with TestLogging {
 
         val query = jvm.monitorGcs(10.seconds)
         assert(jvm.executor.schedules.size == 1)
-        val Seq((r, _, _, _)) = jvm.executor.schedules
+        val r = jvm.executor.schedules.head._1
         val gc0 = Gc(0, "pcopy", Time.now, 1.millisecond)
         val gc1 = Gc(1, "CMS", Time.now, 1.millisecond)
         jvm.pushGc(gc1)

--- a/util-logging/src/test/scala/com/twitter/logging/ScribeHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/ScribeHandlerTest.scala
@@ -36,7 +36,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, WordSpec}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Minutes, Span}
 
 class ScribeHandlerTest extends WordSpec with BeforeAndAfter with Eventually with MockitoSugar {

--- a/util-logging/src/test/scala/com/twitter/logging/ScribeHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/ScribeHandlerTest.scala
@@ -36,8 +36,8 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, WordSpec}
 import org.scalatest.concurrent.Eventually
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Minutes, Span}
+import org.scalatestplus.mockito.MockitoSugar
 
 class ScribeHandlerTest extends WordSpec with BeforeAndAfter with Eventually with MockitoSugar {
   val record1 = new javalog.LogRecord(Level.INFO, "This is a message.")

--- a/util-registry/src/test/scala/com/twitter/util/registry/GlobalRegistryTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/GlobalRegistryTest.scala
@@ -1,6 +1,5 @@
 package com.twitter.util.registry
 
-
 class GlobalRegistryTest extends RegistryTest {
   def mkRegistry(): Registry = GlobalRegistry.withRegistry(new SimpleRegistry) {
     GlobalRegistry.get

--- a/util-registry/src/test/scala/com/twitter/util/registry/RosterTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/RosterTest.scala
@@ -4,7 +4,7 @@ import java.util.logging.Logger
 import org.mockito.Mockito.{never, verify}
 import org.mockito.Matchers.anyObject
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RosterTest extends FunSuite with MockitoSugar {
   def withRoster(fn: (Roster, Logger) => Unit): Unit = {

--- a/util-registry/src/test/scala/com/twitter/util/registry/SimpleRegistryTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/SimpleRegistryTest.scala
@@ -1,6 +1,5 @@
 package com.twitter.util.registry
 
-
 class SimpleRegistryTest extends RegistryTest {
   def mkRegistry(): Registry = new SimpleRegistry
   def name: String = "SimpleRegistry"

--- a/util-security/src/test/scala/com/twitter/util/security/PemFileTestUtils.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/PemFileTestUtils.scala
@@ -52,6 +52,16 @@ object PemFileTestUtils {
     assert(logMessage.contains(expectedExMessage))
   }
 
+  def assertAnyLogMessage(
+    name: String
+  )(logMessage: String,
+    filename: String,
+    expectedExMessages: String*
+  ): Unit = {
+    assert(logMessage.startsWith(s"$name ($filename) failed to load: "))
+    assert(expectedExMessages.exists(expectedExMessage => logMessage.contains(expectedExMessage)))
+  }
+
   def testFileDoesntExist[A](name: String, read: File => Try[A]): Unit = {
     val handler = newHandler()
     val tempFile = File.createTempFile("test", "ext")
@@ -62,7 +72,7 @@ object PemFileTestUtils {
     assert(!tempFile.exists())
 
     val tryReadPem: Try[A] = read(tempFile)
-    assertLogMessage(name)(handler.get, tempFile.getName(), "No such file or directory")
+    assertAnyLogMessage(name)(handler.get, tempFile.getName(), "No such file or directory", "The system cannot find the file specified")
     assertIOException(tryReadPem)
   }
 
@@ -74,7 +84,7 @@ object PemFileTestUtils {
     val parentFile = tempFile.getParentFile()
     val tryReadPem: Try[A] = read(parentFile)
 
-    assertLogMessage(name)(handler.get, parentFile.getName(), "Is a directory")
+    assertAnyLogMessage(name)(handler.get, parentFile.getName(), "Is a directory", "Access is denied")
     assertIOException(tryReadPem)
   }
 

--- a/util-slf4j-api/src/test/scala/com/twitter/util/logging/Item.scala
+++ b/util-slf4j-api/src/test/scala/com/twitter/util/logging/Item.scala
@@ -1,7 +1,5 @@
 package com.twitter.util.logging
 
-import com.twitter.util.logging.Item._
-
 object Item extends Logging {
 
   def baz: String = {
@@ -11,6 +9,7 @@ object Item extends Logging {
 }
 
 class Item(val name: String, val description: String, size: Int) extends Logging {
+  import Item._
   info(s"New item: name = $name, description = $description, size  = $size")
 
   def dimension: Int = {

--- a/util-slf4j-api/src/test/scala/com/twitter/util/logging/LoggingTest.scala
+++ b/util-slf4j-api/src/test/scala/com/twitter/util/logging/LoggingTest.scala
@@ -2,7 +2,7 @@ package com.twitter.util.logging
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
 import org.slf4j
 import scala.language.reflectiveCalls

--- a/util-slf4j-api/src/test/scala/com/twitter/util/logging/MarkerLoggingTest.scala
+++ b/util-slf4j-api/src/test/scala/com/twitter/util/logging/MarkerLoggingTest.scala
@@ -2,7 +2,7 @@ package com.twitter.util.logging
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
 import org.slf4j
 import org.slf4j.Marker

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/CumulativeGauge.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/CumulativeGauge.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.{Function => JFunction}
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import scala.collection.Seq
+import scala.collection.Iterable
 
 /**
  * `CumulativeGauge` provides a [[Gauge gauge]] that is composed of the (addition)

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/CumulativeGauge.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/CumulativeGauge.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.{Function => JFunction}
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.collection.Seq
 
 /**
  * `CumulativeGauge` provides a [[Gauge gauge]] that is composed of the (addition)
@@ -110,19 +111,9 @@ trait StatsReceiverWithCumulativeGauges extends StatsReceiver { self =>
         "of Gauges. Indicative of a leak or code registering the same gauge more " +
         s"often than expected. (For $toString)"
     ) {
-      val largeCgs = gauges.asScala.flatMap {
-        case (ks, cg) =>
-          if (cg.totalSize >= 10000) Some(ks -> cg.totalSize)
-          else None
-      }
-      if (largeCgs.isEmpty) {
-        Nil
-      } else {
-        largeCgs.map {
-          case (ks, size) =>
-            Issue(ks.mkString("/") + "=" + size)
-        }.toSeq
-      }
+      gauges.asScala.collect {
+        case (ks, cg) if (cg.totalSize >= 10000) => Issue(ks.mkString("/") + "=" +cg.totalSize)
+      }.toSeq
     }
   }
 

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
@@ -208,14 +208,10 @@ class InMemoryStatsReceiver extends StatsReceiver with WithHistogramDetails {
     new HistogramDetail {
       def counts: Seq[BucketAndCount] = {
         addedValues
-          .map { x =>
-            nearestPosInt(x)
-          }
-          .groupBy(identity)
-          .mapValues(_.size)
+          .groupBy(nearestPosInt)
+          .map { case (k, vs) => BucketAndCount(k, k+1, vs.size) }
           .toSeq
-          .sortWith(_._1 < _._1)
-          .map { case (k, v) => BucketAndCount(k, k + 1, v) }
+          .sortBy(_.lowerLimit)
       }
     }
   }

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/StatsReceiver.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/StatsReceiver.scala
@@ -150,6 +150,7 @@ trait StatsReceiver {
    * @see [[StatsReceiver.addGauge]] if you can properly control the lifecycle
    *     of the returned [[Gauge gauge]].
    */
+  @varargs
   def provideGauge(name: String*)(f: => Float): Unit = {
     val gauge = addGauge(name: _*)(f)
     StatsReceiver.synchronized {
@@ -174,6 +175,7 @@ trait StatsReceiver {
    *
    * @see [[https://docs.oracle.com/javase/7/docs/api/java/lang/ref/WeakReference.html java.lang.ref.WeakReference]]
    */
+  @varargs
   def addGauge(name: String*)(f: => Float): Gauge = addGauge(Verbosity.Default, name: _*)(f)
 
   /**
@@ -193,6 +195,7 @@ trait StatsReceiver {
    *
    * @see [[https://docs.oracle.com/javase/7/docs/api/java/lang/ref/WeakReference.html java.lang.ref.WeakReference]]
    */
+  @varargs
   def addGauge(verbosity: Verbosity, name: String*)(f: => Float): Gauge
 
   /**

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/StatsReceiver.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/StatsReceiver.scala
@@ -256,4 +256,19 @@ trait StatsReceiver {
   }
 }
 
-abstract class AbstractStatsReceiver extends StatsReceiver
+abstract class AbstractStatsReceiver extends StatsReceiver {
+  @varargs
+  final override def counter(name: String*): Counter = counter(Verbosity.Default, name: _*)
+  @varargs
+  final override def counter(verbosity: Verbosity, name: String*): Counter = counterImpl(verbosity, name)
+  protected def counterImpl(verbosity: Verbosity, name: scala.collection.Seq[String]): Counter
+  @varargs
+  final override def stat(name: String*): Stat = stat(Verbosity.Default, name: _*)
+  @varargs
+  final override def stat(verbosity: Verbosity, name: String*): Stat = statImpl(verbosity, name)
+  protected def statImpl(verbosity: Verbosity, name: scala.collection.Seq[String]): Stat
+  
+  final override def addGauge(name: String*)(f: => Float): Gauge = addGauge(Verbosity.Default, name: _*)(f)
+  final override def addGauge(verbosity: Verbosity, name: String*)(f: => Float): Gauge = addGaugeImpl(verbosity, name, f)
+  protected def addGaugeImpl(verbosity: Verbosity, name: scala.collection.Seq[String], f: => Float): Gauge
+}

--- a/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
+++ b/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
@@ -79,12 +79,9 @@ public final class StatsReceiverCompilationTest {
     final StatsReceiver nullSr = NullStatsReceiver.get();
     StatsReceiver sr = new AbstractStatsReceiver() {
 
-      public Stat stat(Verbosity verbosity, scala.collection.Seq<String> name) {
+      @Override
+      public Stat statImpl(Verbosity verbosity, scala.collection.Seq<String> name) {
         return nullSr.stat(verbosity, name.toSeq());
-      }
-
-      public Stat stat(Verbosity verbosity, scala.collection.immutable.Seq<String> name) {
-        return nullSr.stat(verbosity, name);
       }
       
       @Override
@@ -97,20 +94,13 @@ public final class StatsReceiverCompilationTest {
         return false;
       }
 
-      public Counter counter(Verbosity verbosity, scala.collection.Seq<String> name) {
+      @Override
+      public Counter counterImpl(Verbosity verbosity, scala.collection.Seq<String> name) {
         return nullSr.counter(name.toSeq());
       }
 
-      public Counter counter(Verbosity verbosity, scala.collection.immutable.Seq<String> name) {
-        return nullSr.counter(name);
-      }
-
-      //one of these overrides, which one is a mystery. 
-      public Gauge addGauge(Verbosity verbosity, scala.collection.immutable.Seq<String> name, Function0<Object> f) {
-        return nullSr.addGauge(verbosity, name, f);
-      }
-
-      public Gauge addGauge(Verbosity verbosity, scala.collection.Seq<String> name, Function0<Object> f) {
+      @Override
+      public Gauge addGaugeImpl(Verbosity verbosity, scala.collection.Seq<String> name, Function0<Object> f) {
         return nullSr.addGauge(verbosity, name.toSeq(), f);
       }
     };

--- a/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
+++ b/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
@@ -79,16 +79,14 @@ public final class StatsReceiverCompilationTest {
     final StatsReceiver nullSr = NullStatsReceiver.get();
     StatsReceiver sr = new AbstractStatsReceiver() {
 
-      @Override
-      public Stat stat(Verbosity verbosity, String... name) {
+      public Stat stat(Verbosity verbosity, scala.collection.Seq<String> name) {
+        return nullSr.stat(verbosity, name.toSeq());
+      }
+
+      public Stat stat(Verbosity verbosity, scala.collection.immutable.Seq<String> name) {
         return nullSr.stat(verbosity, name);
       }
       
-      @Override
-      public Stat stat(Verbosity verbosity, scala.collection.Seq<String> name) {
-        return nullSr.stat(verbosity, name.toVector());
-      }
-
       @Override
       public Object repr() {
         return this;
@@ -99,19 +97,21 @@ public final class StatsReceiverCompilationTest {
         return false;
       }
 
-      @Override
-      public Counter counter(Verbosity verbosity, String... name) {
+      public Counter counter(Verbosity verbosity, scala.collection.Seq<String> name) {
+        return nullSr.counter(name.toSeq());
+      }
+
+      public Counter counter(Verbosity verbosity, scala.collection.immutable.Seq<String> name) {
         return nullSr.counter(name);
       }
 
-      @Override
-      public Counter counter(Verbosity verbosity, scala.collection.Seq<String> name){
-        return nullSr.counter(verbosity, name.toVector());
+      //one of these overrides, which one is a mystery. 
+      public Gauge addGauge(Verbosity verbosity, scala.collection.immutable.Seq<String> name, Function0<Object> f) {
+        return nullSr.addGauge(verbosity, name, f);
       }
 
-      @Override
       public Gauge addGauge(Verbosity verbosity, scala.collection.Seq<String> name, Function0<Object> f) {
-        return nullSr.addGauge(verbosity, name.toVector(), f);
+        return nullSr.addGauge(verbosity, name.toSeq(), f);
       }
     };
   }

--- a/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
+++ b/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
@@ -83,6 +83,11 @@ public final class StatsReceiverCompilationTest {
       public Stat stat(Verbosity verbosity, String... name) {
         return nullSr.stat(verbosity, name);
       }
+      
+      @Override
+      public Stat stat(Verbosity verbosity, scala.collection.Seq<String> name) {
+        return nullSr.stat(verbosity, name.toVector());
+      }
 
       @Override
       public Object repr() {
@@ -95,18 +100,18 @@ public final class StatsReceiverCompilationTest {
       }
 
       @Override
-      public Counter counter(Verbosity verbosity, Seq<String> name) {
+      public Counter counter(Verbosity verbosity, String... name) {
         return nullSr.counter(name);
       }
 
       @Override
-      public Stat stat(Verbosity verbosity, Seq<String> name) {
-        return nullSr.stat(name);
+      public Counter counter(Verbosity verbosity, scala.collection.Seq<String> name){
+        return nullSr.counter(verbosity, name.toVector());
       }
 
       @Override
-      public Gauge addGauge(Verbosity verbosity, Seq<String> name, Function0<Object> f) {
-        return nullSr.addGauge(verbosity, name, f);
+      public Gauge addGauge(Verbosity verbosity, scala.collection.Seq<String> name, Function0<Object> f) {
+        return nullSr.addGauge(verbosity, name.toVector(), f);
       }
     };
   }

--- a/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
+++ b/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import scala.Function0;
-import scala.collection.Seq;
+import scala.collection.immutable.Seq;
 
 /**
  * Java compatibility layer for {@link com.twitter.finagle.stats.StatsReceiver}.

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/CategorizingExceptionStatsHandlerTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/CategorizingExceptionStatsHandlerTest.scala
@@ -10,7 +10,7 @@ class CategorizingExceptionStatsHandlerTest extends FunSuite {
 
     val esh = new CategorizingExceptionStatsHandler(
       _ => Some("clienterrors"),
-      PartialFunction.apply(_ => Some("service")),
+      {case _ => Some("service")},
       true
     )
 

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/CumulativeGaugeTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/CumulativeGaugeTest.scala
@@ -62,10 +62,11 @@ class CumulativeGaugeTest extends FunSuite {
       assert(0 == gauge.numDeregisters.get)
 
       added = null
-      System.gc()
-      gauge.cleanRefs()
-
-      assert(gauge.getValue == 0.0f)
+      for(i <- 1 to 10) {
+        System.gc()
+        gauge.cleanRefs()
+        assert(gauge.getValue == 0.0f)
+      }
       assert(gauge.numDeregisters.get > 0)
     }
 

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
@@ -2,9 +2,9 @@ package com.twitter.finagle.stats
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class DelegatingStatsReceiverTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class DelegatingStatsReceiverTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   class Ctx {
     var leafCounter = 0

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
@@ -4,6 +4,7 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import scala.collection.parallel.immutable.ParRange
 
 class InMemoryStatsReceiverTest extends FunSuite with Eventually with IntegrationPatience {
 
@@ -30,7 +31,7 @@ class InMemoryStatsReceiverTest extends FunSuite with Eventually with Integratio
 
   test("threadsafe counter") {
     val inMemoryStatsReceiver = new InMemoryStatsReceiver
-    (1 to 50).par.foreach(_ => inMemoryStatsReceiver.counter("same").incr())
+    new ParRange(1 to 50).foreach(_ => inMemoryStatsReceiver.counter("same").incr())
     eventually {
       assert(inMemoryStatsReceiver.counter("same")() == 50)
     }
@@ -38,7 +39,7 @@ class InMemoryStatsReceiverTest extends FunSuite with Eventually with Integratio
 
   test("threadsafe stats") {
     val inMemoryStatsReceiver = new InMemoryStatsReceiver
-    (1 to 50).par.foreach(_ => inMemoryStatsReceiver.stat("same").add(1.0f))
+    new ParRange(1 to 50).foreach(_ => inMemoryStatsReceiver.stat("same").add(1.0f))
     eventually {
       assert(inMemoryStatsReceiver.stat("same")().size == 50)
     }

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
@@ -40,7 +40,7 @@ class StatsReceiverTest extends FunSuite {
     assert(c2.c == 1)
 
     class MemStat extends Stat {
-      var values: Seq[Float] = ArrayBuffer.empty[Float]
+      var values: scala.collection.Seq[Float] = ArrayBuffer.empty[Float]
       def add(f: Float): Unit = { values = values :+ f }
     }
     val s1 = new MemStat

--- a/util-test/src/main/scala/com/twitter/logging/TestLogging.scala
+++ b/util-test/src/main/scala/com/twitter/logging/TestLogging.scala
@@ -66,7 +66,7 @@ trait TestLogging extends BeforeAndAfter { self: WordSpec =>
     logger.addHandler(traceHandler)
   }
 
-  def logLines(): Seq[String] = traceHandler.get.split("\n")
+  def logLines(): Seq[String] = traceHandler.get.split("\n").toSeq
 
   /**
    * Verify that the logger set up with `traceLogger` has received a log line with the given

--- a/util-test/src/test/scala/com/twitter/util/testing/ArgumentCaptureTest.scala
+++ b/util-test/src/test/scala/com/twitter/util/testing/ArgumentCaptureTest.scala
@@ -3,7 +3,7 @@ package com.twitter.util.testing
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ArgumentCaptureTest extends FunSuite with MockitoSugar with ArgumentCapture {
   class MockSubject {

--- a/util-zk/src/main/scala/com/twitter/zk/AsyncCallbackPromise.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/AsyncCallbackPromise.scala
@@ -23,13 +23,13 @@ trait AsyncCallbackPromise[T] extends Promise[T] {
 
 class StringCallbackPromise extends AsyncCallbackPromise[String] with AsyncCallback.StringCallback {
   def processResult(rc: Int, path: String, ctx: AnyRef, name: String): Unit = {
-    process(rc, path) { name }
+    process(rc, path)(name)
   }
 }
 
 class UnitCallbackPromise extends AsyncCallbackPromise[Unit] with AsyncCallback.VoidCallback {
   def processResult(rc: Int, path: String, ctx: AnyRef): Unit = {
-    process(rc, path) { Unit }
+    process(rc, path)(())
   }
 }
 

--- a/util-zk/src/main/scala/com/twitter/zk/NativeConnector.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/NativeConnector.scala
@@ -48,16 +48,16 @@ case class NativeConnector(
    */
   def apply(): Future[ZooKeeper] =
     serialized {
-      connection getOrElse {
+      connection.getOrElse {
         val c = mkConnection
         c.sessionEvents foreach { event =>
           sessionBroker.send(event()).sync()
         }
         connection = Some(c)
         c
-      } apply ()
+      }.apply
     }.flatten
-      .rescue {
+     .rescue {
         case e: NativeConnector.ConnectTimeoutException =>
           release() flatMap { _ =>
             Future.exception(e)
@@ -194,7 +194,7 @@ object NativeConnector {
         log.debug("release")
         zk.close()
         zookeeper = None
-        releasePromise.setValue(Unit)
+        releasePromise.setValue(())
       }
     }
   }

--- a/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
@@ -239,7 +239,7 @@ trait ZNode {
             removed = knownChildren -- children
           )
           log.debug("updating %s with %d children", path, treeUpdate.added.size)
-          broker send (treeUpdate) sync () onSuccess { _ =>
+          broker.send(treeUpdate).sync.onSuccess { _ =>
             log.debug("updated %s with %d children", path, treeUpdate.added.size)
             treeUpdate.added foreach { z =>
               pipeSubTreeUpdates(z.monitorTree())
@@ -256,7 +256,7 @@ trait ZNode {
           // Tell the broker about the children we lost; otherwise, if there were no children,
           // this deletion should be reflected in a watch on the parent node, if one exists.
           if (knownChildren.size > 0) {
-            broker send (ZNode.TreeUpdate(this, removed = knownChildren)) sync ()
+            broker.send(ZNode.TreeUpdate(this, removed = knownChildren)).sync
           } else {
             Future.Done
           } onSuccess { _ =>

--- a/util-zk/src/main/scala/com/twitter/zk/ZkClient.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZkClient.scala
@@ -42,7 +42,7 @@ trait ZkClient {
   /* Settings */
 
   /** Default: Creator access */
-  val acl: Seq[ACL] = CREATOR_ALL_ACL.asScala
+  val acl: Seq[ACL] = CREATOR_ALL_ACL.asScala.toSeq
 
   /** Build a ZkClient with another default creation ACL. */
   def withAcl(a: Seq[ACL]): ZkClient = transform(_acl = a)

--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ShardCoordinator.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ShardCoordinator.scala
@@ -100,9 +100,9 @@ class ShardCoordinator(zk: ZkClient, path: String, numShards: Int) {
 
   private[this] def shardNodes(): Future[Seq[ZNode]] = {
     zk(path).getChildren() map { zop =>
-      zop.children filter { child =>
+      (zop.children filter { child =>
         child.path.startsWith(shardPathPrefix)
-      } sortBy (child => shardIdOf(child.path))
+      } sortBy (child => shardIdOf(child.path))).toSeq
     }
   }
 

--- a/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/coordination/ZkAsyncSemaphore.scala
@@ -161,9 +161,9 @@ class ZkAsyncSemaphore(
    *         The sequence includes both nodes that have entered the semaphore as well as waiters.
    */
   private[this] def permitNodes(): Future[Seq[ZNode]] = {
-    futureSemaphoreNode flatMap { semaphoreNode =>
+    futureSemaphoreNode.flatMap { semaphoreNode =>
       semaphoreNode.getChildren() map { zop =>
-        zop.children filter { child =>
+        zop.children.toSeq filter { child =>
           child.path.startsWith(permitNodePathPrefix)
         } sortBy (child => sequenceNumberOf(child.path))
       }
@@ -181,7 +181,7 @@ class ZkAsyncSemaphore(
     val monitor = node.getChildren.monitor()
     monitor foreach { tryChildren =>
       tryChildren map { zop =>
-        checkWaiters(zop.children)
+        checkWaiters(zop.children.toSeq)
       }
     }
   }

--- a/util-zk/src/test/scala/com/twitter/zk/ConnectorTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ConnectorTest.scala
@@ -2,7 +2,7 @@ package com.twitter.zk
 
 import org.mockito.Mockito._
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import com.twitter.util.Future
 

--- a/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
@@ -4,7 +4,7 @@ package com.twitter.zk
  * @author ver@twitter.com
  */
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ZNodeTest extends WordSpec with MockitoSugar {
   "ZNode" should {

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
@@ -4,7 +4,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, JavaTimer}
@@ -22,7 +22,7 @@ class ShardCoordinatorTest extends WordSpec with MockitoSugar {
         val connector = NativeConnector(connectString, 5.seconds, 10.minutes)
         val zk = ZkClient(connector)
           .withRetryPolicy(RetryPolicy.Basic(3))
-          .withAcl(OPEN_ACL_UNSAFE.asScala)
+          .withAcl(OPEN_ACL_UNSAFE.asScala.toSeq)
 
         Await.result(Future { f(zk) } ensure { zk.release })
       }

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -10,7 +10,7 @@ import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import scala.collection.JavaConverters._
 
@@ -27,7 +27,7 @@ class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertio
         val connector = NativeConnector(connectString, 5.seconds, 10.minutes)
         val zk = ZkClient(connector)
           .withRetryPolicy(RetryPolicy.Basic(3))
-          .withAcl(OPEN_ACL_UNSAFE.asScala)
+          .withAcl(OPEN_ACL_UNSAFE.asScala.toSeq)
 
         Await.result(Future { f(zk) } ensure { zk.release })
       }

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -10,8 +10,8 @@ import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.concurrent.Eventually._
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.JavaConverters._
 
 class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertions {


### PR DESCRIPTION
Aim for (but not always accomplish) source compatibility

Prefer to use "default" `Seq` over `scala.collection.Seq`

Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

Align with 2.13.0 collections

Result

Building under 2.13.0




