### PR TITLE
remove all RunWith

### DIFF
--- a/util-cache-guava/src/test/scala/com/twitter/cache/guava/GuavaCacheTest.scala
+++ b/util-cache-guava/src/test/scala/com/twitter/cache/guava/GuavaCacheTest.scala
@@ -3,10 +3,7 @@ package com.twitter.cache.guava
 import com.google.common.cache.{CacheLoader, CacheBuilder}
 import com.twitter.cache.AbstractFutureCacheTest
 import com.twitter.util.{Future, Promise}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class GuavaCacheTest extends AbstractFutureCacheTest {
   def name: String = "GuavaCache"
 

--- a/util-cache-guava/src/test/scala/com/twitter/cache/guava/LoadingFutureCacheTest.scala
+++ b/util-cache-guava/src/test/scala/com/twitter/cache/guava/LoadingFutureCacheTest.scala
@@ -3,10 +3,7 @@ package com.twitter.cache.guava
 import com.google.common.cache.{CacheLoader, CacheBuilder}
 import com.twitter.cache.AbstractLoadingFutureCacheTest
 import com.twitter.util.Future
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class LoadingFutureCacheTest extends AbstractLoadingFutureCacheTest {
 
   def name: String = "LoadingFutureCache (guava)"

--- a/util-cache/src/test/scala/com/twitter/cache/ConcurrentMapCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/ConcurrentMapCacheTest.scala
@@ -2,10 +2,7 @@ package com.twitter.cache
 
 import com.twitter.util.Future
 import java.util.concurrent.ConcurrentHashMap
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ConcurrentMapCacheTest extends AbstractFutureCacheTest {
   def name: String = "ConcurrentMapCache"
 

--- a/util-cache/src/test/scala/com/twitter/cache/EvictingCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/EvictingCacheTest.scala
@@ -2,13 +2,10 @@ package com.twitter.cache
 
 import com.twitter.util.{Promise, Future}
 import java.util.concurrent.ConcurrentHashMap
-import org.junit.runner.RunWith
 import org.mockito.Mockito.{verify, never}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
-@RunWith(classOf[JUnitRunner])
 class EvictingCacheTest extends FunSuite with MockitoSugar {
   test("EvictingCache should evict on failed futures for set") {
     val cache = mock[FutureCache[String, String]]

--- a/util-cache/src/test/scala/com/twitter/cache/KeyEncodingCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/KeyEncodingCacheTest.scala
@@ -2,10 +2,7 @@ package com.twitter.cache
 
 import java.util.concurrent.ConcurrentHashMap
 import com.twitter.util.Future
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class KeyEncodingCacheTest extends AbstractFutureCacheTest {
   def name: String = "KeyEncodingCache"
 

--- a/util-cache/src/test/scala/com/twitter/cache/caffeine/CaffeineCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/caffeine/CaffeineCacheTest.scala
@@ -3,10 +3,7 @@ package com.twitter.cache.caffeine
 import com.github.benmanes.caffeine.cache.{Caffeine, CacheLoader, LoadingCache}
 import com.twitter.cache.AbstractFutureCacheTest
 import com.twitter.util.{Future, Promise}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CaffeineCacheTest extends AbstractFutureCacheTest {
   def name: String = "CaffeineCache"
 

--- a/util-cache/src/test/scala/com/twitter/cache/caffeine/LoadingFutureCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/caffeine/LoadingFutureCacheTest.scala
@@ -3,10 +3,7 @@ package com.twitter.cache.caffeine
 import com.github.benmanes.caffeine.cache.{Caffeine, CacheLoader}
 import com.twitter.cache.AbstractLoadingFutureCacheTest
 import com.twitter.util.Future
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class LoadingFutureCacheTest extends AbstractLoadingFutureCacheTest {
 
   def name: String = "LoadingFutureCache (caffeine)"

--- a/util-codec/src/test/scala/com/twitter/util/StringEncoderTest.scala
+++ b/util-codec/src/test/scala/com/twitter/util/StringEncoderTest.scala
@@ -18,11 +18,8 @@ package com.twitter.util
 
 import java.lang.StringBuilder
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class StringEncoderTest extends WordSpec {
   val longString =
     "A string that is really really really really really really long and has more than 76 characters"
@@ -38,7 +35,6 @@ class StringEncoderTest extends WordSpec {
   }
 }
 
-@RunWith(classOf[JUnitRunner])
 class Base64StringEncoderTest extends WordSpec {
   val urlUnsafeBytes = Array(-1.toByte, -32.toByte)
   val resultUnsafe = "/+A"
@@ -59,7 +55,6 @@ class Base64StringEncoderTest extends WordSpec {
   }
 }
 
-@RunWith(classOf[JUnitRunner])
 class GZIPStringEncoderTest extends WordSpec {
   "a gzip string encoder" should {
     val gse = new GZIPStringEncoder {}

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncMeterTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncMeterTest.scala
@@ -3,11 +3,8 @@ package com.twitter.concurrent
 import com.twitter.util._
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.{RejectedExecutionException, CancellationException}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class AsyncMeterTest extends FunSuite {
   import AsyncMeter._
 

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncMutexTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncMutexTest.scala
@@ -1,12 +1,8 @@
 package com.twitter.concurrent
 
-import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
-import org.scalatest.junit.JUnitRunner
-
 import com.twitter.util.Await
 
-@RunWith(classOf[JUnitRunner])
 class AsyncMutexTest extends FlatSpec {
   "AsyncMutex" should "admit only one operation at a time" in {
     val m = new AsyncMutex

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncSemaphoreTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncSemaphoreTest.scala
@@ -3,13 +3,10 @@ package com.twitter.concurrent
 import com.twitter.conversions.DurationOps._
 import com.twitter.util._
 import java.util.concurrent.{ConcurrentLinkedQueue, RejectedExecutionException, CountDownLatch}
-import org.junit.runner.RunWith
 import org.scalatest.fixture.FunSpec
-import org.scalatest.junit.JUnitRunner
 import scala.collection.mutable
 import org.scalatest.Outcome
 
-@RunWith(classOf[JUnitRunner])
 class AsyncSemaphoreTest extends FunSpec {
   class AsyncSemaphoreHelper(
     val sem: AsyncSemaphore,

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -2,13 +2,10 @@ package com.twitter.concurrent
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util._
-import org.junit.runner.RunWith
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-@RunWith(classOf[JUnitRunner])
 class AsyncStreamTest extends FunSuite with GeneratorDrivenPropertyChecks {
   import AsyncStream.{mk, of}
   import AsyncStreamTest._

--- a/util-core/src/test/scala/com/twitter/concurrent/BrokerTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/BrokerTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.concurrent
 
 import com.twitter.util.{Await, Return, ObjectSizeCalculator}
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class BrokerTest extends WordSpec {
   "Broker" should {
     "send data (send, recv)" in {

--- a/util-core/src/test/scala/com/twitter/concurrent/OfferTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/OfferTest.scala
@@ -2,10 +2,8 @@ package com.twitter.concurrent
 
 import scala.util.Random
 
-import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
 import com.twitter.conversions.DurationOps._
@@ -22,7 +20,6 @@ class SimpleOffer[T](var futures: Stream[Future[Tx[T]]]) extends Offer[T] {
   }
 }
 
-@RunWith(classOf[JUnitRunner])
 class OfferTest extends WordSpec with MockitoSugar {
   import Tx.{Commit, Abort}
 

--- a/util-core/src/test/scala/com/twitter/concurrent/OnceTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/OnceTest.scala
@@ -2,11 +2,8 @@ package com.twitter.concurrent
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Promise, Await}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class OnceTest extends FunSuite {
   test("Once.apply should only be applied once") {
     var x = 0

--- a/util-core/src/test/scala/com/twitter/concurrent/PeriodTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/PeriodTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.concurrent
 
 import com.twitter.conversions.DurationOps._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class PeriodTest extends FunSuite {
   test("Period#numPeriods should behave reasonably") {
     val period = new Period(1.second)

--- a/util-core/src/test/scala/com/twitter/concurrent/SchedulerTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SchedulerTest.scala
@@ -4,10 +4,8 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util._
 import java.util.concurrent.{Executors, TimeUnit}
 import java.util.logging.{Handler, Level, LogRecord}
-import org.junit.runner.RunWith
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.JUnitRunner
 
 abstract class LocalSchedulerTest(lifo: Boolean) extends FunSuite with Matchers {
   private val scheduler = new LocalScheduler(lifo)
@@ -154,13 +152,10 @@ abstract class LocalSchedulerTest(lifo: Boolean) extends FunSuite with Matchers 
 
 }
 
-@RunWith(classOf[JUnitRunner])
 class LocalSchedulerFifoTest extends LocalSchedulerTest(false)
 
-@RunWith(classOf[JUnitRunner])
 class LocalSchedulerLifoTest extends LocalSchedulerTest(true)
 
-@RunWith(classOf[JUnitRunner])
 class ThreadPoolSchedulerTest extends FunSuite with Eventually with IntegrationPatience {
   test("works") {
     val p = new Promise[Unit]

--- a/util-core/src/test/scala/com/twitter/concurrent/SerializedTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SerializedTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.concurrent
 
 import java.util.concurrent.CountDownLatch
-
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
-@RunWith(classOf[JUnitRunner])
+
 class SerializedTest extends WordSpec with Serialized {
   "Serialized" should {
     "runs blocks, one at a time, in the order received" in {

--- a/util-core/src/test/scala/com/twitter/concurrent/SpoolSourceTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SpoolSourceTest.scala
@@ -2,11 +2,8 @@ package com.twitter.concurrent
 
 import com.twitter.util.{Return, Await}
 import java.util.concurrent.atomic.AtomicInteger
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class SpoolSourceTest extends WordSpec {
   "SpoolSource" should {
     class SpoolSourceHelper {

--- a/util-core/src/test/scala/com/twitter/concurrent/SpoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SpoolTest.scala
@@ -4,14 +4,11 @@ import com.twitter.concurrent.Spool.{*::, seqToSpool}
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, Promise, Return, Throw}
 import java.io.EOFException
-import org.junit.runner.RunWith
 import org.scalacheck.Arbitrary
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import scala.collection.mutable.ArrayBuffer
 
-@RunWith(classOf[JUnitRunner])
 class SpoolTest extends WordSpec with GeneratorDrivenPropertyChecks {
   "Empty Spool" should {
     val s = Spool.empty[Int]

--- a/util-core/src/test/scala/com/twitter/concurrent/TxTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/TxTest.scala
@@ -1,12 +1,8 @@
 package com.twitter.concurrent
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
-
 import com.twitter.util.Return
 
-@RunWith(classOf[JUnitRunner])
 class TxTest extends WordSpec {
   "Tx.twoParty" should {
     "commit when everything goes dandy" in {

--- a/util-core/src/test/scala/com/twitter/io/BufInputStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufInputStreamTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.io
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class BufInputStreamTest extends FunSuite {
   private[this] val fileString =
     "Test_All_Tests\nTest_java_io_BufferedInputStream\nTest_java_io_BufferedOutputStream\nTest_ByteArrayInputStream\nTest_java_io_ByteArrayOutputStream\nTest_java_io_DataInputStream\n"

--- a/util-core/src/test/scala/com/twitter/io/BufReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufReaderTest.scala
@@ -2,12 +2,9 @@ package com.twitter.io
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.Checkers
 
-@RunWith(classOf[JUnitRunner])
 class BufReaderTest extends FunSuite with Checkers {
 
   private def await[A](f: Future[A]): A = Await.result(f, 5.seconds)

--- a/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
@@ -2,13 +2,10 @@ package com.twitter.io
 
 import java.lang.{Double => JDouble, Float => JFloat}
 import java.nio.charset.StandardCharsets
-import org.junit.runner.RunWith
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-@RunWith(classOf[JUnitRunner])
 class ByteReaderTest extends FunSuite with GeneratorDrivenPropertyChecks {
   import ByteReader._
 

--- a/util-core/src/test/scala/com/twitter/io/FilesTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/FilesTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.io
 
 import java.io.File
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class FilesTest extends WordSpec with TempFolder {
   "Files" should {
 

--- a/util-core/src/test/scala/com/twitter/io/InputStreamReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/InputStreamReaderTest.scala
@@ -3,12 +3,9 @@ package com.twitter.io
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, FuturePool}
 import java.io.ByteArrayInputStream
-import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class InputStreamReaderTest extends FunSuite {
   def arr(i: Int, j: Int): Array[Byte] = Array.range(i, j).map(_.toByte)
   def buf(i: Int, j: Int): Buf = Buf.ByteArray.Owned(arr(i, j))

--- a/util-core/src/test/scala/com/twitter/io/StreamIOTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/StreamIOTest.scala
@@ -2,11 +2,8 @@ package com.twitter.io
 
 import scala.util.Random
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class StreamIOTest extends WordSpec {
   "StreamIO.copy" should {
     "copy the entire stream" in {

--- a/util-core/src/test/scala/com/twitter/io/TempDirectoryTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/TempDirectoryTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.io
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class TempDirectoryTest extends WordSpec {
 
   "TempDirectory" should {

--- a/util-core/src/test/scala/com/twitter/io/TempFileTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/TempFileTest.scala
@@ -2,12 +2,8 @@ package com.twitter.io
 
 import java.io.{ByteArrayInputStream, DataInputStream}
 import java.util.Arrays
-
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class TempFileTest extends WordSpec {
 
   "TempFile" should {

--- a/util-core/src/test/scala/com/twitter/io/exp/ActivitySourceTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/exp/ActivitySourceTest.scala
@@ -3,12 +3,9 @@ package com.twitter.io.exp
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, FuturePool, MockTimer, Time}
 import java.io.{File, ByteArrayInputStream}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import scala.util.Random
 
-@RunWith(classOf[JUnitRunner])
 class ActivitySourceTest extends FunSuite with BeforeAndAfter {
 
   val ok: ActivitySource[String] = new ActivitySource[String] {

--- a/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.util
 
 import java.util.concurrent.atomic.AtomicReference
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ActivityTest extends FunSuite {
   test("Activity#flatMap") {
     val v = Var(Activity.Pending: Activity.State[Int])

--- a/util-core/src/test/scala/com/twitter/util/BoundedStackTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/BoundedStackTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class BoundedStackTest extends WordSpec {
   "BoundedStack" should {
     "empty" in {

--- a/util-core/src/test/scala/com/twitter/util/CancellableTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/CancellableTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CancellableTest extends WordSpec {
   "CancellableSink" should {
     "cancel once" in {

--- a/util-core/src/test/scala/com/twitter/util/ClosableTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ClosableTest.scala
@@ -1,13 +1,10 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.JUnitRunner
 import scala.language.reflectiveCalls
 
-@RunWith(classOf[JUnitRunner])
 class ClosableTest extends FunSuite with Eventually with IntegrationPatience {
   test("Closable.close(Duration)") {
     Time.withCurrentTimeFrozen { _ =>

--- a/util-core/src/test/scala/com/twitter/util/CloseAwaitablyTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/CloseAwaitablyTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CloseAwaitablyTest extends FunSuite {
   class Context extends Closable with CloseAwaitably {
     val p: Promise[Unit] = new Promise[Unit]

--- a/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.{Matchers, WordSpec}
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ConfigTest extends WordSpec with Matchers {
   import Config._
 

--- a/util-core/src/test/scala/com/twitter/util/CredentialsTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/CredentialsTest.scala
@@ -16,12 +16,9 @@
 
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.Checkers
 
-@RunWith(classOf[JUnitRunner])
 class CredentialsTest extends FunSuite with Checkers {
   test("parse a simple auth file") {
     val content = "username: root\npassword: hellokitty\n"

--- a/util-core/src/test/scala/com/twitter/util/DiffTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DiffTest.scala
@@ -1,12 +1,9 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-@RunWith(classOf[JUnitRunner])
 class DiffTest extends FunSuite with GeneratorDrivenPropertyChecks {
   val f: Int => String = _.toString
 

--- a/util-core/src/test/scala/com/twitter/util/DurationTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DurationTest.scala
@@ -18,10 +18,7 @@ package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.TimeUnit
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class DurationTest extends { val ops: Duration.type = Duration } with TimeLikeSpec[Duration] {
 
   "Duration" should {

--- a/util-core/src/test/scala/com/twitter/util/EventTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/EventTest.scala
@@ -3,11 +3,8 @@ package com.twitter.util
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{CountDownLatch, Executors}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
-import org.junit.runner.RunWith
 import scala.collection.mutable
 
-@RunWith(classOf[JUnitRunner])
 class EventTest extends FunSuite {
 
   test("pub/sub while active") {

--- a/util-core/src/test/scala/com/twitter/util/FutureOfferTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureOfferTest.scala
@@ -1,13 +1,9 @@
 package com.twitter.concurrent
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
-
 import com.twitter.util.{Promise, Return}
 
-@RunWith(classOf[JUnitRunner])
 class FutureOfferTest extends WordSpec with MockitoSugar {
   "Future.toOffer" should {
     "activate when future is satisfied (poll)" in {

--- a/util-core/src/test/scala/com/twitter/util/FuturePoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FuturePoolTest.scala
@@ -2,15 +2,12 @@ package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.{Future => JFuture, _}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.time.{Millis, Seconds, Span}
 import scala.runtime.NonLocalReturnControl
 import scala.util.control.NonFatal
 
-@RunWith(classOf[JUnitRunner])
 class FuturePoolTest extends FunSuite with Eventually {
 
   implicit override val patienceConfig: PatienceConfig =

--- a/util-core/src/test/scala/com/twitter/util/LastWriteWinsQueueTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/LastWriteWinsQueueTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class LastWriteWinsQueueTest extends WordSpec {
   "LastWriteWinsQueue" should {
     val queue = new LastWriteWinsQueue[String]

--- a/util-core/src/test/scala/com/twitter/util/MemoizeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/MemoizeTest.scala
@@ -3,12 +3,9 @@ package com.twitter.util
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{TimeUnit, CountDownLatch => JavaCountDownLatch}
-import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class MemoizeTest extends FunSuite {
   test("Memoize.apply: only runs the function once for the same input") {
     // mockito can't spy anonymous classes,

--- a/util-core/src/test/scala/com/twitter/util/NetUtilTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/NetUtilTest.scala
@@ -2,11 +2,8 @@ package com.twitter.util
 
 import java.net.InetAddress
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class NetUtilTest extends WordSpec {
   "NetUtil" should {
     "isIpv4Address" in {

--- a/util-core/src/test/scala/com/twitter/util/PoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PoolTest.scala
@@ -2,13 +2,10 @@ package com.twitter.util
 
 import scala.collection.mutable
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
 import com.twitter.conversions.DurationOps._
 
-@RunWith(classOf[JUnitRunner])
 class PoolTest extends WordSpec {
   "SimplePool" should {
     "with a simple queue of items" should {

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class PromiseTest extends FunSuite {
 
   test("Promise.detach should not detach other attached promises") {

--- a/util-core/src/test/scala/com/twitter/util/StateMachineTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/StateMachineTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class StateMachineTest extends WordSpec {
   "StateMachine" should {
     class StateMachineHelper {

--- a/util-core/src/test/scala/com/twitter/util/StorageUnitTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/StorageUnitTest.scala
@@ -1,12 +1,9 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.twitter.conversions.StorageUnitOps._
 
-@RunWith(classOf[JUnitRunner])
 class StorageUnitTest extends FunSuite {
   test("StorageUnit: should convert whole numbers into storage units (back and forth)") {
     assert(1.byte.inBytes == 1)

--- a/util-core/src/test/scala/com/twitter/util/ThrowablesTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ThrowablesTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ThrowablesTest extends FunSuite {
   test("Throwables.mkString: flatten non-nested exception") {
     val t = new Throwable

--- a/util-core/src/test/scala/com/twitter/util/TimeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimeTest.scala
@@ -4,10 +4,8 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 import java.util.{Locale, TimeZone}
 import java.util.concurrent.TimeUnit
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 import com.twitter.conversions.DurationOps._
@@ -373,7 +371,6 @@ trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with GeneratorDrivenProper
   }
 }
 
-@RunWith(classOf[JUnitRunner])
 class TimeFormatTest extends WordSpec {
   "TimeFormat" should {
     "format correctly with non US locale" in {
@@ -398,7 +395,6 @@ class TimeFormatTest extends WordSpec {
   }
 }
 
-@RunWith(classOf[JUnitRunner])
 class TimeTest extends { val ops: Time.type = Time } with TimeLikeSpec[Time] with Eventually
 with IntegrationPatience {
 

--- a/util-core/src/test/scala/com/twitter/util/TimerTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimerTest.scala
@@ -3,16 +3,13 @@ package com.twitter.util
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.{CancellationException, ExecutorService, TimeUnit, CountDownLatch}
 import java.util.concurrent.atomic.AtomicInteger
-import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{IntegrationPatience, Eventually}
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
-@RunWith(classOf[JUnitRunner])
 class TimerTest extends FunSuite with MockitoSugar with Eventually with IntegrationPatience {
 
   private def testTimerRunsWithLocals(timer: Timer): Unit = {

--- a/util-core/src/test/scala/com/twitter/util/TokenBucketTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TokenBucketTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import com.twitter.conversions.DurationOps._
 
-@RunWith(classOf[JUnitRunner])
 class TokenBucketTest extends FunSuite {
   test("a leaky bucket is leaky") {
     Time.withCurrentTimeFrozen { tc =>

--- a/util-core/src/test/scala/com/twitter/util/TryTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TryTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class TryTest extends FunSuite {
   class MyException extends Exception
   val e: Exception = new Exception("this is an exception")

--- a/util-core/src/test/scala/com/twitter/util/TwitterDateFormatTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TwitterDateFormatTest.scala
@@ -2,11 +2,8 @@ package com.twitter.util
 
 import java.util.Locale
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class TwitterDateFormatTest extends WordSpec {
   "TwitterDateFormat" should {
     "disallow Y without w" in {

--- a/util-core/src/test/scala/com/twitter/util/VarTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/VarTest.scala
@@ -1,14 +1,11 @@
 package com.twitter.util
 
 import java.util.concurrent.atomic.AtomicReference
-import org.junit.runner.RunWith
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import scala.collection.mutable
 
-@RunWith(classOf[JUnitRunner])
 class VarTest extends FunSuite with GeneratorDrivenPropertyChecks {
   private case class U[T](init: T) extends UpdatableVar[T](init) {
     import Var.Observer

--- a/util-core/src/test/scala/com/twitter/util/WindowedAdderTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/WindowedAdderTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class WindowedAdderTest extends FunSuite {
   private def newAdder() = WindowedAdder(3 * 1000, 3, Stopwatch.timeMillis)
 

--- a/util-hashing/src/test/scala/com/twitter/hashing/DiagnosticsTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/DiagnosticsTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.hashing
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class DiagnosticsTest extends WordSpec {
   "Diagnostics" should {
     "print distribution" in {

--- a/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.hashing
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-@RunWith(classOf[JUnitRunner])
 class HashableTest extends FunSuite with GeneratorDrivenPropertyChecks {
 
   private[this] val algorithms = Seq(

--- a/util-hashing/src/test/scala/com/twitter/hashing/KetamaDistributorTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/KetamaDistributorTest.scala
@@ -1,16 +1,13 @@
 package com.twitter.hashing
 
-import org.junit.runner.RunWith
 import org.scalacheck.Gen
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import scala.collection.mutable
 import java.io.{BufferedReader, InputStreamReader}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.security.MessageDigest
 
-@RunWith(classOf[JUnitRunner])
 class KetamaDistributorTest extends WordSpec with GeneratorDrivenPropertyChecks {
   "KetamaDistributor" should {
     val nodes = Seq(

--- a/util-hashing/src/test/scala/com/twitter/hashing/KeyHasherTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/KeyHasherTest.scala
@@ -2,13 +2,10 @@ package com.twitter.hashing
 
 import com.twitter.io.TempFile
 import java.util.Base64
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import scala.collection.mutable.ListBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 
-@RunWith(classOf[JUnitRunner])
 class KeyHasherTest extends WordSpec {
   def readResource(name: String) = {
     var lines = new ListBuffer[String]()

--- a/util-lint/src/test/scala/com/twitter/util/lint/RuleTest.scala
+++ b/util-lint/src/test/scala/com/twitter/util/lint/RuleTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util.lint
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class RuleTest extends FunSuite {
 
   private def withName(name: String): Rule =

--- a/util-lint/src/test/scala/com/twitter/util/lint/RulesTest.scala
+++ b/util-lint/src/test/scala/com/twitter/util/lint/RulesTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util.lint
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class RulesTest extends FunSuite {
 
   private var flag = false

--- a/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
@@ -18,15 +18,12 @@ package com.twitter.logging
 
 import java.io._
 import java.util.{Calendar, Date, logging => javalog}
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import com.twitter.conversions.StorageUnitOps._
 import com.twitter.conversions.DurationOps._
 import com.twitter.io.TempFolder
 import com.twitter.util.Time
 
-@RunWith(classOf[JUnitRunner])
 class FileHandlerTest extends WordSpec with TempFolder {
   def reader(filename: String) = {
     new BufferedReader(new InputStreamReader(new FileInputStream(new File(folderName, filename))))

--- a/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
@@ -18,13 +18,10 @@ package com.twitter.logging
 
 import java.util.{logging => javalog}
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
 import com.twitter.conversions.StringOps._
 
-@RunWith(classOf[JUnitRunner])
 class FormatterTest extends WordSpec {
   val basicFormatter = new Formatter
 

--- a/util-logging/src/test/scala/com/twitter/logging/HasLogLevelTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/HasLogLevelTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.logging
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class HasLogLevelTest extends FunSuite {
 
   private class WithLogLevel(val logLevel: Level, cause: Throwable = null)

--- a/util-logging/src/test/scala/com/twitter/logging/LogRecordTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LogRecordTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.logging
 
 import java.util.logging.{LogRecord => JRecord}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class LogRecordTest extends FunSuite {
   test("LogRecord should getMethod properly") {
     Logger.withLoggers(Nil) {

--- a/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
@@ -21,12 +21,9 @@ import com.twitter.io.TempFolder
 import java.net.InetSocketAddress
 import java.util.concurrent.{Callable, CountDownLatch, Executors, Future, TimeUnit}
 import java.util.{logging => javalog}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, WordSpec}
 import scala.collection.mutable
 
-@RunWith(classOf[JUnitRunner])
 class LoggerTest extends WordSpec with TempFolder with BeforeAndAfter {
   val logLevel =
     Logger.levelNames(Option[String](System.getenv("log")).getOrElse("FATAL").toUpperCase)

--- a/util-logging/src/test/scala/com/twitter/logging/PolicyTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/PolicyTest.scala
@@ -1,12 +1,9 @@
 package com.twitter.logging
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.twitter.util.StorageUnit
 
-@RunWith(classOf[JUnitRunner])
 class PolicyTest extends FunSuite {
   import Policy._
 

--- a/util-logging/src/test/scala/com/twitter/logging/QueueingHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/QueueingHandlerTest.scala
@@ -18,12 +18,9 @@ package com.twitter.logging
 
 import com.twitter.util.Local
 import java.util.{logging => javalog}
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.{IntegrationPatience, Eventually}
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class QueueingHandlerTest extends WordSpec with Eventually with IntegrationPatience {
 
   class MockHandler extends Handler(BareFormatter, None) {

--- a/util-logging/src/test/scala/com/twitter/logging/SyslogHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/SyslogHandlerTest.scala
@@ -19,11 +19,8 @@ package com.twitter.logging
 import java.net.{DatagramPacket, DatagramSocket}
 import java.util.{logging => javalog}
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class SyslogHandlerTest extends WordSpec {
   val record1 = new javalog.LogRecord(Level.FATAL, "fatal message!")
   record1.setLoggerName("net.lag.whiskey.Train")

--- a/util-reflect/src/test/scala/com/twitter/util/reflect/ProxyTest.scala
+++ b/util-reflect/src/test/scala/com/twitter/util/reflect/ProxyTest.scala
@@ -1,9 +1,7 @@
 package com.twitter.util.reflect
 
 import com.twitter.util.{Future, Promise, Stopwatch}
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
 object ProxySpec {
   trait TestInterface {
@@ -34,7 +32,6 @@ object ProxySpec {
   }
 }
 
-@RunWith(classOf[JUnitRunner])
 class ProxyTest extends WordSpec {
 
   import ProxySpec._

--- a/util-registry/src/test/scala/com/twitter/util/registry/FormatterTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/FormatterTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.util.registry
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import scala.util.control.NoStackTrace
 
-@RunWith(classOf[JUnitRunner])
 class FormatterTest extends FunSuite {
   test("asMap generates reasonable Maps") {
     val registry = new SimpleRegistry

--- a/util-registry/src/test/scala/com/twitter/util/registry/GlobalRegistryTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/GlobalRegistryTest.scala
@@ -1,9 +1,6 @@
 package com.twitter.util.registry
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class GlobalRegistryTest extends RegistryTest {
   def mkRegistry(): Registry = GlobalRegistry.withRegistry(new SimpleRegistry) {
     GlobalRegistry.get

--- a/util-registry/src/test/scala/com/twitter/util/registry/LibraryTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/LibraryTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util.registry
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 
-@RunWith(classOf[JUnitRunner])
 class LibraryTest extends FunSuite {
   test("Library.register registers libraries") {
     val simple = new SimpleRegistry

--- a/util-registry/src/test/scala/com/twitter/util/registry/RosterTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/RosterTest.scala
@@ -3,12 +3,9 @@ package com.twitter.util.registry
 import java.util.logging.Logger
 import org.mockito.Mockito.{never, verify}
 import org.mockito.Matchers.anyObject
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 import org.scalatest.mockito.MockitoSugar
 
-@RunWith(classOf[JUnitRunner])
 class RosterTest extends FunSuite with MockitoSugar {
   def withRoster(fn: (Roster, Logger) => Unit): Unit = {
     val simple = new SimpleRegistry

--- a/util-registry/src/test/scala/com/twitter/util/registry/SimpleRegistryTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/SimpleRegistryTest.scala
@@ -1,9 +1,6 @@
 package com.twitter.util.registry
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class SimpleRegistryTest extends RegistryTest {
   def mkRegistry(): Registry = new SimpleRegistry
   def name: String = "SimpleRegistry"

--- a/util-security/src/test/scala/com/twitter/util/security/PemFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/PemFileTest.scala
@@ -3,11 +3,8 @@ package com.twitter.util.security
 import com.twitter.io.TempFile
 import com.twitter.util.Try
 import java.io.File
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class PemFileTest extends FunSuite {
 
   private[this] val assertLogMessage =

--- a/util-security/src/test/scala/com/twitter/util/security/Pkcs8EncodedKeySpecFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/Pkcs8EncodedKeySpecFileTest.scala
@@ -4,11 +4,8 @@ import com.twitter.io.TempFile
 import com.twitter.util.Try
 import java.io.File
 import java.security.spec.PKCS8EncodedKeySpec
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class Pkcs8EncodedKeySpecFileTest extends FunSuite {
 
   private[this] val assertLogMessage =

--- a/util-security/src/test/scala/com/twitter/util/security/X500PrincipalInfoTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/X500PrincipalInfoTest.scala
@@ -1,11 +1,8 @@
 package com.twitter.util.security
 
 import javax.security.auth.x500.X500Principal
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class X500PrincipalInfoTest extends FunSuite {
 
   test("Empty principal") {

--- a/util-security/src/test/scala/com/twitter/util/security/X509CertificateFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/X509CertificateFileTest.scala
@@ -4,11 +4,8 @@ import com.twitter.io.TempFile
 import com.twitter.util.Try
 import java.io.File
 import java.security.cert.{CertificateException, X509Certificate}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class X509CertificateFileTest extends FunSuite {
 
   private[this] def assertIsCslCert(cert: X509Certificate): Unit = {

--- a/util-security/src/test/scala/com/twitter/util/security/X509TrustManagerFactoryTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/X509TrustManagerFactoryTest.scala
@@ -4,11 +4,8 @@ import com.twitter.io.TempFile
 import java.io.File
 import java.security.cert.X509Certificate
 import javax.net.ssl.{TrustManager, X509TrustManager}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class X509TrustManagerFactoryTest extends FunSuite {
 
   private[this] def loadCertFromResource(resourcePath: String): X509Certificate = {

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/BroadcastStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/BroadcastStatsReceiverTest.scala
@@ -2,11 +2,8 @@ package com.twitter.finagle.stats
 
 import com.twitter.util.{Future, Await}
 
-import org.junit.runner.RunWith
 import org.scalatest.{Matchers, FunSuite}
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class BroadcastStatsReceiverTest extends FunSuite with Matchers {
 
   test("counter") {

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/CategorizingExceptionStatsHandlerTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/CategorizingExceptionStatsHandlerTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.finagle.stats
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CategorizingExceptionStatsHandlerTest extends FunSuite {
   val categorizer = (t: Throwable) => { "clienterrors" }
 

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
@@ -1,12 +1,9 @@
 package com.twitter.finagle.stats
 
-import org.junit.runner.RunWith
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-@RunWith(classOf[JUnitRunner])
 class DelegatingStatsReceiverTest extends FunSuite with GeneratorDrivenPropertyChecks {
 
   class Ctx {

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
@@ -2,12 +2,9 @@ package com.twitter.finagle.stats
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class InMemoryStatsReceiverTest extends FunSuite with Eventually with IntegrationPatience {
 
   // scalafix:off StoreGaugesAsMemberVariables

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/MultiCategorizingExceptionStatsHandlerTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/MultiCategorizingExceptionStatsHandlerTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.finagle.stats
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class MultiCategorizingExceptionStatsHandlerTest extends FunSuite {
   test("uses label, flags, source, exception chain and rolls up") {
     val receiver = new InMemoryStatsReceiver

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
@@ -3,13 +3,10 @@ package com.twitter.finagle.stats
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future}
 import java.util.concurrent.TimeUnit
-import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import scala.collection.mutable.ArrayBuffer
 
-@RunWith(classOf[JUnitRunner])
 class StatsReceiverTest extends FunSuite {
   test("RollupStatsReceiver counter/stats") {
     val mem = new InMemoryStatsReceiver

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/WithHistogramDetailsTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/WithHistogramDetailsTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.finagle.stats
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class WithHistogramDetailsTest extends FunSuite {
   test("AggregateWithHistogramDetails rejects empties") {
     intercept[IllegalArgumentException] {

--- a/util-test/src/test/scala/com/twitter/util/testing/ArgumentCaptureTest.scala
+++ b/util-test/src/test/scala/com/twitter/util/testing/ArgumentCaptureTest.scala
@@ -1,13 +1,10 @@
 package com.twitter.util.testing
 
-import org.junit.runner.RunWith
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
-@RunWith(classOf[JUnitRunner])
 class ArgumentCaptureTest extends FunSuite with MockitoSugar with ArgumentCapture {
   class MockSubject {
     def method1(arg: String): Long = 0L

--- a/util-thrift/src/test/scala/com/twitter/util/ThriftCodecTest.scala
+++ b/util-thrift/src/test/scala/com/twitter/util/ThriftCodecTest.scala
@@ -1,10 +1,7 @@
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ThriftCodecTest extends FunSuite {
 
   private def roundTrip(codec: ThriftCodec[TestThriftStructure, _]): Unit = {

--- a/util-thrift/src/test/scala/com/twitter/util/ThriftSerializerTest.scala
+++ b/util-thrift/src/test/scala/com/twitter/util/ThriftSerializerTest.scala
@@ -16,11 +16,8 @@
 
 package com.twitter.util
 
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ThriftSerializerTest extends WordSpec {
   val aString = "me gustan los tacos y los burritos"
   val aNumber = 42

--- a/util-zk-test/src/test/scala/com/twitter/zk/ServerCnxnFactoryTest.scala
+++ b/util-zk-test/src/test/scala/com/twitter/zk/ServerCnxnFactoryTest.scala
@@ -4,11 +4,8 @@ import com.twitter.io.TempDirectory
 import java.io.File
 import java.net.InetAddress
 import org.apache.zookeeper.server.ZooKeeperServer
-import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ServerCnxnFactoryTest extends FunSuite with BeforeAndAfter {
   val addr = InetAddress.getLocalHost
 

--- a/util-zk/src/test/scala/com/twitter/zk/ConnectorTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ConnectorTest.scala
@@ -1,14 +1,11 @@
 package com.twitter.zk
 
-import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
 import com.twitter.util.Future
 
-@RunWith(classOf[JUnitRunner])
 class ConnectorTest extends WordSpec with MockitoSugar {
   "Connector.RoundRobin" should {
     "require underlying connections" in {

--- a/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
@@ -3,12 +3,9 @@ package com.twitter.zk
 /**
  * @author ver@twitter.com
  */
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
-@RunWith(classOf[JUnitRunner])
 class ZNodeTest extends WordSpec with MockitoSugar {
   "ZNode" should {
     class ZNodeSpecHelper {

--- a/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
@@ -5,21 +5,18 @@ import scala.collection.Set
 
 import org.apache.zookeeper._
 import org.apache.zookeeper.data.{ACL, Stat}
-import org.junit.runner.RunWith
 import org.mockito.Matchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.logging.{Level, Logger}
 import com.twitter.util._
 
-@RunWith(classOf[JUnitRunner])
 class ZkClientTest extends WordSpec with MockitoSugar {
   Logger.get("").setLevel(Level.FATAL)
 

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
@@ -3,16 +3,13 @@ package com.twitter.zk.coordination
 import scala.collection.JavaConverters._
 
 import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, JavaTimer}
 import com.twitter.zk.{NativeConnector, RetryPolicy, ZkClient}
 
-@RunWith(classOf[JUnitRunner])
 class ShardCoordinatorTest extends WordSpec with MockitoSugar {
 
   "ShardCoordinator" should {

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -7,16 +7,13 @@ import com.twitter.zk.{NativeConnector, RetryPolicy, ZkClient, ZNode}
 import java.util.concurrent.ConcurrentLinkedQueue
 import org.apache.zookeeper.KeeperException.NoNodeException
 import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
-import org.junit.runner.RunWith
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import scala.collection.JavaConverters._
 
-@RunWith(classOf[JUnitRunner])
 class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertions {
 
   "ZkAsyncSemaphore" should {


### PR DESCRIPTION
Problem

Superfluous calls to RunWith will require changes to the import for JUnitRunner.

Solution

Remove all RunWith and associated changes

Result

Code that won't need to be changed in the future to address deprecated alias for JUnitRunner
