### PR TITLE
App close race condition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,12 @@ Runtime Behavior Changes
 
 * util: Upgrade to Jackson 2.9.9. ``PHAB_ID=D345969``
 
+Bug Fixes
+~~~~~~~~~
+
+* util-app: Fixed race-condition in `com.twitter.app.App` where the App could be kept running if
+  `App#close` is not fulfilled within the graceful period
+
 19.7.0
 ------
 

--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -64,6 +64,10 @@ trait App extends Closable with CloseAwaitably {
    */
   protected def failfastOnFlagsNotParsed: Boolean = false
 
+
+  /** Forcibly exit the JVM without cleanup */
+  protected def kill(): Unit = System.exit(1)
+
   /** Exit on error with the given Throwable */
   protected def exitOnError(throwable: Throwable): Unit = {
     throwable.printStackTrace()
@@ -71,7 +75,7 @@ trait App extends Closable with CloseAwaitably {
       case _: CloseException =>
         // exception occurred while closing, do not attempt to close again
         System.err.println(throwable.getMessage)
-        System.exit(1)
+        kill()
       case _ =>
         exitOnError("Exception thrown in main on startup")
     }
@@ -94,7 +98,7 @@ trait App extends Closable with CloseAwaitably {
     System.err.flush()
     System.err.println(details)
     Await.ready(close(), closeDeadline - Time.now)
-    System.exit(1)
+    kill()
   }
 
   /**

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -311,6 +311,21 @@ class AppTest extends FunSuite {
     assert(closed)
   }
 
+  test("App: exit even if the ShutdownTimer doesn't schedule timeout promptly") {
+    val app = new TestApp(() => ()) {
+     // We use a MockTimer to simulate jitter in the scheduling of timeout
+     override protected lazy val shutdownTimer = new MockTimer
+     def tick() = shutdownTimer.tick()
+    }
+
+    app.closeOnExit(Closable.make { _ => Future.never })
+
+    assert(!app.killed)
+    app.main(Array.empty)
+    app.tick()
+    assert(app.killed)
+  }
+
   test("App: exit functions properly capture non-fatal exceptions") {
     val app = new ErrorOnExitApp {
       def main(): Unit = {

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -48,7 +48,7 @@ class AppTest extends FunSuite {
     test1.main(Array())
 
     assert(test1.reason.contains("Exception thrown in main on startup"))
-    assert(app.killed)
+    assert(test1.killed)
   }
 
   test("App: propagate underlying exception from fields in app") {

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -9,8 +9,15 @@ import scala.language.reflectiveCalls
 
 class TestApp(f: () => Unit) extends App {
   var reason: Option[String] = None
+  var killed: Boolean = false
+
+  protected override def kill(): Unit = {
+    killed = true
+  }
+
   protected override def exitOnError(reason: String, details: => String): Unit = {
     this.reason = Some(reason)
+    super.exitOnError(reason, details)
   }
 
   def main(): Unit = f()
@@ -41,6 +48,7 @@ class AppTest extends FunSuite {
     test1.main(Array())
 
     assert(test1.reason.contains("Exception thrown in main on startup"))
+    assert(app.killed)
   }
 
   test("App: propagate underlying exception from fields in app") {


### PR DESCRIPTION
Problem

There's a race-condition in the close sequence of `com.twitter.app.App` when `close` doesn't meet the deadline. Normally, if the close sequence take longer than the graceful period, `closing` should be fulfilled by a `CloseException` due to [this](https://github.com/twitter/util/blob/util-19.7.0/util-app/src/main/scala/com/twitter/app/App.scala#L285) and [this](https://github.com/twitter/util/blob/util-19.7.0/util-app/src/main/scala/com/twitter/app/App.scala#L317) which is caught [here](https://github.com/twitter/util/blob/util-19.7.0/util-app/src/main/scala/com/twitter/app/App.scala#L71) and cause the JVM to be killed. However if this `Await.result` throw a `TimeoutException` before that, the app can be kept in a bad state.

Solution

Catch `TimeoutException` by `Await.result` and convert them into `CloseException`

Result

The App will always call `System.exit(1)` if `App#close` doesn't meet the deadline.