### PR TITLE
Make flatMap on AsyncStream stack-safe

### DIFF
--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -735,10 +735,16 @@ class AsyncStreamTest extends FunSuite with GeneratorDrivenPropertyChecks {
       }
     }
 
-    test(s"$impl: tailRecM is stack-safe") {
+    test(s"$impl: flatMap is stack-safe") {
       val n = 10000
 
-      val stream = AsyncStream.tailRecM(0) { i =>
+      def tailRecM[A, B](a: A)(f: A => AsyncStream[Either[A, B]]): AsyncStream[B] =
+        f(a).flatMap {
+          case Right(b) => AsyncStream.of(b)
+          case Left(a) => tailRecM(a)(f)
+        }
+
+      val stream = tailRecM(0) { i =>
         AsyncStream.of(if (i < n) Left(i + 1) else Right(i))
       }
 

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -735,6 +735,15 @@ class AsyncStreamTest extends FunSuite with GeneratorDrivenPropertyChecks {
       }
     }
 
+    test(s"$impl: tailRecM is stack-safe") {
+      val n = 10000
+
+      val stream = AsyncStream.tailRecM(0) { i =>
+        AsyncStream.of(if (i < n) Left(i + 1) else Right(i))
+      }
+
+      assert(Await.result(stream.toSeq) == Seq(n))
+    }
   }
 
 }


### PR DESCRIPTION
## Problem

The recent `com.twitter.util.BypassScheduler` optimization breaks stack-safety for monadic recursion for `AsyncStream`. For example, on 19.7.0 or 19.8.0 (or 19.6.0 with `-Dcom.twitter.util.BypassScheduler=true`) the following will overflow, while it used to work just fine:

```scala
import com.twitter.concurrent.AsyncStream

def deep(i: Int): AsyncStream[Int] =
  if (i == 0) AsyncStream.of(i) else AsyncStream.of(i).flatMap(i => deep(i - 1))

com.twitter.util.Await.result(deep(10000).toSeq)
```

## Solution

After some discussion we decided the best solution would be to replace `Future#map` with `Future#flatMap` in the definition of `AsyncStream`'s `flatMap` in order to make it stack-safe again.

~~I've added a new `tailRecM` method to the `AsyncStream` companion object that provides stack-safe monadic recursion via a (private) `stackSafeFlatMap` method that uses `flatMap`s on `Future` instead of `map`. I've also added a test and verified that it fails with the naive `flatMap`-based `tailRecM` implementation.~~

~~The name `tailRecM` is pretty standard: it's used in Cats and in other libraries and languages.~~

## Result

`flatMap` can be used recursively again without worrying about stack overflows.