### PR TITLE
remove bad varargs annotations

### DIFF
--- a/util-stats/src/main/scala/com/twitter/finagle/stats/StatsReceiver.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/StatsReceiver.scala
@@ -150,7 +150,6 @@ trait StatsReceiver {
    * @see [[StatsReceiver.addGauge]] if you can properly control the lifecycle
    *     of the returned [[Gauge gauge]].
    */
-  @varargs
   def provideGauge(name: String*)(f: => Float): Unit = {
     val gauge = addGauge(name: _*)(f)
     StatsReceiver.synchronized {
@@ -175,7 +174,6 @@ trait StatsReceiver {
    *
    * @see [[https://docs.oracle.com/javase/7/docs/api/java/lang/ref/WeakReference.html java.lang.ref.WeakReference]]
    */
-  @varargs
   def addGauge(name: String*)(f: => Float): Gauge = addGauge(Verbosity.Default, name: _*)(f)
 
   /**
@@ -195,7 +193,6 @@ trait StatsReceiver {
    *
    * @see [[https://docs.oracle.com/javase/7/docs/api/java/lang/ref/WeakReference.html java.lang.ref.WeakReference]]
    */
-  @varargs
   def addGauge(verbosity: Verbosity, name: String*)(f: => Float): Gauge
 
   /**


### PR DESCRIPTION
`@varargs` only makes sense when the varargs are the last thing in
the last parameter list. that isn't true here.

this fixes a problem where the code failed to compile on JDK 11,
with errors such as

```
/Users/tisue/community.211-11/target-0.9.16/project-builds/twitter-util-715c1151a337e4a30659436b6cafc90bf8f35c6f/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java:21:1: cannot access com.twitter.finagle.stats.StatsReceiver
bad class file: /Users/tisue/community.211-11/target-0.9.16/project-builds/twitter-util-715c1151a337e4a30659436b6cafc90bf8f35c6f/util-stats/target/scala-2.11/classes/com/twitter/finagle/stats/StatsReceiver.class
class file contains malformed variable arity method: provideGauge(java.lang.String[],scala.Function0<java.lang.Object>)
```