### PR TITLE
util-stats: Limit the max stats in InMemoryStatsReceiver

### DIFF
--- a/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
@@ -118,7 +118,11 @@ class InMemoryStatsReceiver(maxStats: Int) extends StatsReceiver with WithHistog
 
       def add(value: Float): Unit = stats.synchronized {
         val oldValue = apply()
-        stats(schema.metricBuilder.name) = oldValue.takeRight(maxStats) :+ value
+        if(maxStats > 0) {
+          stats(schema.metricBuilder.name) = oldValue.takeRight(maxStats) :+ value
+        } else {
+          stats(schema.metricBuilder.name) = oldValue :+ value
+        }
       }
       def apply(): Seq[Float] = stats.getOrElse(schema.metricBuilder.name, Seq.empty)
 

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
@@ -50,8 +50,10 @@ object InMemoryStatsReceiver {
  *
  * @param maxStats the maximum number of stats, zero or negative value means unlimited (default is unlimited)
  **/
-class InMemoryStatsReceiver(maxStats: Int = 0) extends StatsReceiver with WithHistogramDetails {
+class InMemoryStatsReceiver(maxStats: Int) extends StatsReceiver with WithHistogramDetails {
   import InMemoryStatsReceiver._
+
+  def this() = this(0)
 
   def repr: InMemoryStatsReceiver = this
 
@@ -116,16 +118,7 @@ class InMemoryStatsReceiver(maxStats: Int = 0) extends StatsReceiver with WithHi
 
       def add(value: Float): Unit = stats.synchronized {
         val oldValue = apply()
-
-        // Limit the maximum number of stats as 10000000
-        val length = oldValue.length
-        val tailValue = if (maxStats <= 0 || length < maxStats) {
-          oldValue
-        } else {
-          oldValue.drop(length - maxStats + 1)
-        }
-
-        stats(schema.metricBuilder.name) = tailValue :+ value
+        stats(schema.metricBuilder.name) = oldValue.takeRight(maxStats) :+ value
       }
       def apply(): Seq[Float] = stats.getOrElse(schema.metricBuilder.name, Seq.empty)
 

--- a/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
+++ b/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
@@ -23,7 +23,7 @@ public final class StatsReceiverCompilationTest {
 
   @Test
   public void testStatMethods() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
     Stat stat = sr.stat("hello", "world");
     Callable<Integer> callable = new Callable<Integer>() {
       public Integer call() {
@@ -46,7 +46,7 @@ public final class StatsReceiverCompilationTest {
 
   @Test
   public void testGaugeMethods() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
     Callable<Float> callable = new Callable<Float>() {
       public Float call() {
         return 3.0f;
@@ -59,7 +59,7 @@ public final class StatsReceiverCompilationTest {
 
   @Test
   public void testCounterMethods() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
     sr.isNull();
     Counter counter = sr.counter("hello", "world");
     counter.incr();
@@ -67,7 +67,7 @@ public final class StatsReceiverCompilationTest {
   }
 
   public void testScope() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
     StatsReceiver sr2 = sr.scope();
     StatsReceiver sr3 = sr.scope("a");
     StatsReceiver sr4 = sr.scope("a", "s", "d");

--- a/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
+++ b/util-stats/src/test/java/com/twitter/finagle/stats/StatsReceiverCompilationTest.java
@@ -23,7 +23,7 @@ public final class StatsReceiverCompilationTest {
 
   @Test
   public void testStatMethods() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
     Stat stat = sr.stat("hello", "world");
     Callable<Integer> callable = new Callable<Integer>() {
       public Integer call() {
@@ -46,7 +46,7 @@ public final class StatsReceiverCompilationTest {
 
   @Test
   public void testGaugeMethods() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
     Callable<Float> callable = new Callable<Float>() {
       public Float call() {
         return 3.0f;
@@ -59,7 +59,7 @@ public final class StatsReceiverCompilationTest {
 
   @Test
   public void testCounterMethods() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
     sr.isNull();
     Counter counter = sr.counter("hello", "world");
     counter.incr();
@@ -67,7 +67,7 @@ public final class StatsReceiverCompilationTest {
   }
 
   public void testScope() {
-    InMemoryStatsReceiver sr = new InMemoryStatsReceiver(0);
+    InMemoryStatsReceiver sr = new InMemoryStatsReceiver();
     StatsReceiver sr2 = sr.scope();
     StatsReceiver sr3 = sr.scope("a");
     StatsReceiver sr4 = sr.scope("a", "s", "d");


### PR DESCRIPTION
## Problem

`InMemoryStatsReceiver` keeps all added stats in memory so it consumes the heap infinitely.

## Solution

This pull request enables to limit the maximum number of stats stored in memory. The default is no limitation as before.