### PR TITLE
util-core: remove early initializer for TimeLike

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Duration.scala
+++ b/util-core/src/main/scala/com/twitter/util/Duration.scala
@@ -304,7 +304,7 @@ private[util] object DurationBox {
  * that are truly infinite; for example the absence of a timeout.
  */
 sealed class Duration private[util] (protected val nanos: Long) extends TimeLike[Duration] with Serializable {
-  override def ops: TimeLikeOps[Duration] = Duration
+  override val ops: TimeLikeOps[Duration] = Duration
   import Duration._
 
   def inNanoseconds: Long = nanos

--- a/util-core/src/main/scala/com/twitter/util/Duration.scala
+++ b/util-core/src/main/scala/com/twitter/util/Duration.scala
@@ -304,10 +304,8 @@ private[util] object DurationBox {
  * their arithmetic follows. This is useful for representing durations
  * that are truly infinite; for example the absence of a timeout.
  */
-sealed class Duration private[util] (protected val nanos: Long) extends {
-  protected val ops: Duration.type = Duration
-} with TimeLike[Duration] with Serializable {
-  import ops._
+sealed class Duration private[util] (protected val nanos: Long) extends TimeLike[Duration](Duration) with Serializable {
+  import Duration._
 
   def inNanoseconds: Long = nanos
 

--- a/util-core/src/main/scala/com/twitter/util/Duration.scala
+++ b/util-core/src/main/scala/com/twitter/util/Duration.scala
@@ -4,7 +4,6 @@ import java.io.Serializable
 import java.util.concurrent.TimeUnit
 
 object Duration extends TimeLikeOps[Duration] {
-
   def fromNanoseconds(nanoseconds: Long): Duration =
     if (nanoseconds == 0L) Zero
     else new Duration(nanoseconds)
@@ -304,7 +303,8 @@ private[util] object DurationBox {
  * their arithmetic follows. This is useful for representing durations
  * that are truly infinite; for example the absence of a timeout.
  */
-sealed class Duration private[util] (protected val nanos: Long) extends TimeLike[Duration](Duration) with Serializable {
+sealed class Duration private[util] (protected val nanos: Long) extends TimeLike[Duration] with Serializable {
+  override def ops: TimeLikeOps[Duration] = Duration
   import Duration._
 
   def inNanoseconds: Long = nanos

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -138,8 +138,8 @@ trait TimeLikeOps[This <: TimeLike[This]] {
  *
  * Overflows are also handled like doubles.
  */
-abstract class TimeLike[This <: TimeLike[This]](protected val ops: TimeLikeOps[This]) extends Ordered[This] { self: This =>
-  import ops._
+trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
+  protected def ops: TimeLikeOps[This]
 
   /** The `TimeLike`'s value in nanoseconds. */
   def inNanoseconds: Long
@@ -181,14 +181,14 @@ abstract class TimeLike[This <: TimeLike[This]](protected val ops: TimeLikeOps[T
     def addNanos(a: Long, b: Long): This = {
       val c = a + b
       if (((a ^ c) & (b ^ c)) < 0)
-        if (b < 0) Bottom else Top
-      else fromNanoseconds(c)
+        if (b < 0) ops.Bottom else ops.Top
+      else ops.fromNanoseconds(c)
     }
 
     delta match {
-      case Duration.Top => Top
-      case Duration.Bottom => Bottom
-      case Duration.Undefined => Undefined
+      case Duration.Top => ops.Top
+      case Duration.Bottom => ops.Bottom
+      case Duration.Undefined => ops.Undefined
       case ns => addNanos(inNanoseconds, ns.inNanoseconds)
     }
   }
@@ -222,12 +222,12 @@ abstract class TimeLike[This <: TimeLike[This]](protected val ops: TimeLikeOps[T
    * results because of timezones.
    */
   def floor(increment: Duration): This = (this, increment) match {
-    case (num, ns) if num.isZero && ns.isZero => Undefined
-    case (num, ns) if num.isFinite && ns.isZero => if (num.inNanoseconds < 0) Bottom else Top
+    case (num, ns) if num.isZero && ns.isZero => ops.Undefined
+    case (num, ns) if num.isFinite && ns.isZero => if (num.inNanoseconds < 0) ops.Bottom else ops.Top
     case (num, denom) if num.isFinite && denom.isFinite =>
-      fromNanoseconds((num.inNanoseconds / denom.inNanoseconds) * denom.inNanoseconds)
+      ops.fromNanoseconds((num.inNanoseconds / denom.inNanoseconds) * denom.inNanoseconds)
     case (self, n) if n.isFinite => self
-    case (_, _) => Undefined
+    case (_, _) => ops.Undefined
   }
 
   def max(that: This): This =
@@ -237,15 +237,15 @@ abstract class TimeLike[This <: TimeLike[This]](protected val ops: TimeLikeOps[T
     if ((this compare that) < 0) this else that
 
   def compare(that: This): Int =
-    if ((that eq Top) || (that eq Undefined)) -1
-    else if (that eq Bottom) 1
+    if ((that eq ops.Top) || (that eq ops.Undefined)) -1
+    else if (that eq ops.Bottom) 1
     else if (inNanoseconds < that.inNanoseconds) -1
     else if (inNanoseconds > that.inNanoseconds) 1
     else 0
 
   /** Equality within `maxDelta` */
   def moreOrLessEquals(other: This, maxDelta: Duration): Boolean =
-    (other ne Undefined) && ((this == other) || (this diff other).abs <= maxDelta)
+    (other ne ops.Undefined) && ((this == other) || (this diff other).abs <= maxDelta)
 }
 
 /**
@@ -584,7 +584,8 @@ class TimeFormat(
  * @see [[Stopwatch]] for measuring elapsed time.
  * @see [[TimeFormat]] for converting to and from `String` representations.
  */
-sealed class Time private[util] (protected val nanos: Long) extends TimeLike[Time](Time) with Serializable {
+sealed class Time private[util] (protected val nanos: Long) extends TimeLike[Time] with Serializable {
+  override def ops: TimeLikeOps[Time] = Time
   import Time._
 
   def inNanoseconds: Long = nanos

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -139,7 +139,8 @@ trait TimeLikeOps[This <: TimeLike[This]] {
  * Overflows are also handled like doubles.
  */
 trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
-  protected def ops: TimeLikeOps[This]
+  protected val ops: TimeLikeOps[This]
+  import ops._
 
   /** The `TimeLike`'s value in nanoseconds. */
   def inNanoseconds: Long
@@ -181,14 +182,14 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
     def addNanos(a: Long, b: Long): This = {
       val c = a + b
       if (((a ^ c) & (b ^ c)) < 0)
-        if (b < 0) ops.Bottom else ops.Top
-      else ops.fromNanoseconds(c)
+        if (b < 0) Bottom else Top
+      else fromNanoseconds(c)
     }
 
     delta match {
-      case Duration.Top => ops.Top
-      case Duration.Bottom => ops.Bottom
-      case Duration.Undefined => ops.Undefined
+      case Duration.Top => Top
+      case Duration.Bottom => Bottom
+      case Duration.Undefined => Undefined
       case ns => addNanos(inNanoseconds, ns.inNanoseconds)
     }
   }
@@ -222,12 +223,12 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
    * results because of timezones.
    */
   def floor(increment: Duration): This = (this, increment) match {
-    case (num, ns) if num.isZero && ns.isZero => ops.Undefined
-    case (num, ns) if num.isFinite && ns.isZero => if (num.inNanoseconds < 0) ops.Bottom else ops.Top
+    case (num, ns) if num.isZero && ns.isZero => Undefined
+    case (num, ns) if num.isFinite && ns.isZero => if (num.inNanoseconds < 0) Bottom else Top
     case (num, denom) if num.isFinite && denom.isFinite =>
-      ops.fromNanoseconds((num.inNanoseconds / denom.inNanoseconds) * denom.inNanoseconds)
+      fromNanoseconds((num.inNanoseconds / denom.inNanoseconds) * denom.inNanoseconds)
     case (self, n) if n.isFinite => self
-    case (_, _) => ops.Undefined
+    case (_, _) => Undefined
   }
 
   def max(that: This): This =
@@ -237,15 +238,15 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
     if ((this compare that) < 0) this else that
 
   def compare(that: This): Int =
-    if ((that eq ops.Top) || (that eq ops.Undefined)) -1
-    else if (that eq ops.Bottom) 1
+    if ((that eq Top) || (that eq Undefined)) -1
+    else if (that eq Bottom) 1
     else if (inNanoseconds < that.inNanoseconds) -1
     else if (inNanoseconds > that.inNanoseconds) 1
     else 0
 
   /** Equality within `maxDelta` */
   def moreOrLessEquals(other: This, maxDelta: Duration): Boolean =
-    (other ne ops.Undefined) && ((this == other) || (this diff other).abs <= maxDelta)
+    (other ne Undefined) && ((this == other) || (this diff other).abs <= maxDelta)
 }
 
 /**
@@ -585,7 +586,7 @@ class TimeFormat(
  * @see [[TimeFormat]] for converting to and from `String` representations.
  */
 sealed class Time private[util] (protected val nanos: Long) extends TimeLike[Time] with Serializable {
-  override def ops: TimeLikeOps[Time] = Time
+  override val ops: TimeLikeOps[Time] = Time
   import Time._
 
   def inNanoseconds: Long = nanos

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -138,8 +138,7 @@ trait TimeLikeOps[This <: TimeLike[This]] {
  *
  * Overflows are also handled like doubles.
  */
-trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
-  protected val ops: TimeLikeOps[This]
+abstract class TimeLike[This <: TimeLike[This]](protected val ops: TimeLikeOps[This]) extends Ordered[This] { self: This =>
   import ops._
 
   /** The `TimeLike`'s value in nanoseconds. */
@@ -585,10 +584,8 @@ class TimeFormat(
  * @see [[Stopwatch]] for measuring elapsed time.
  * @see [[TimeFormat]] for converting to and from `String` representations.
  */
-sealed class Time private[util] (protected val nanos: Long) extends {
-  protected val ops: Time.type = Time
-} with TimeLike[Time] with Serializable {
-  import ops._
+sealed class Time private[util] (protected val nanos: Long) extends TimeLike[Time](Time) with Serializable {
+  import Time._
 
   def inNanoseconds: Long = nanos
 


### PR DESCRIPTION
Problem

Early initializers are deprecated and will be removed in a future version of scala.

Solution

Replace `TimeLike` trait with abstract class, and put `ops` in a constructor parameter instead of it being a value that needs to be early-initialized

Result

No more early initializers for future compatibility.