### PR TITLE
util: replace deprecated JavaConverters

### DIFF
--- a/util-app/src/main/scala/com/twitter/app/App.scala
+++ b/util-app/src/main/scala/com/twitter/app/App.scala
@@ -6,7 +6,7 @@ import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Logger
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal
 

--- a/util-app/src/main/scala/com/twitter/app/ClassPath.scala
+++ b/util-app/src/main/scala/com/twitter/app/ClassPath.scala
@@ -8,7 +8,7 @@ import java.nio.file.Paths
 import java.util.jar.{JarEntry, JarFile}
 import scala.collection.mutable
 import scala.collection.mutable.Builder
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.io.Source
 
 private[app] object ClassPath {

--- a/util-app/src/main/scala/com/twitter/app/Flaggable.scala
+++ b/util-app/src/main/scala/com/twitter/app/Flaggable.scala
@@ -11,7 +11,7 @@ import java.lang.{
 }
 import java.net.InetSocketAddress
 import java.util.{List => JList, Map => JMap, Set => JSet}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * A type class providing evidence for parsing type `T` as a flag value.

--- a/util-app/src/main/scala/com/twitter/app/Flags.scala
+++ b/util-app/src/main/scala/com/twitter/app/Flags.scala
@@ -1,6 +1,6 @@
 package com.twitter.app
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable.TreeSet
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/util-app/src/main/scala/com/twitter/app/LoadService.scala
+++ b/util-app/src/main/scala/com/twitter/app/LoadService.scala
@@ -6,7 +6,7 @@ import java.util.ServiceConfigurationError
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.{Function => JFunction}
 import java.util.logging.{Level, Logger}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.io.Source
 import scala.reflect.ClassTag

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -101,7 +101,7 @@ class AppTest extends FunSuite {
   }
 
   test("App: order of hooks") {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val q = new ConcurrentLinkedQueue[Int]
     class Test1 extends App {

--- a/util-core/src/main/scala/com/twitter/concurrent/AsyncSemaphore.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/AsyncSemaphore.scala
@@ -4,7 +4,7 @@ import com.twitter.util._
 import java.util.ArrayDeque
 import java.util.concurrent.RejectedExecutionException
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 /**

--- a/util-core/src/main/scala/com/twitter/util/Activity.scala
+++ b/util-core/src/main/scala/com/twitter/util/Activity.scala
@@ -2,7 +2,7 @@ package com.twitter.util
 
 import java.util.{List => JList}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.Buffer
 import scala.language.higherKinds
 import scala.reflect.ClassTag

--- a/util-core/src/main/scala/com/twitter/util/Awaitable.scala
+++ b/util-core/src/main/scala/com/twitter/util/Awaitable.scala
@@ -3,7 +3,7 @@ package com.twitter.util
 import com.twitter.concurrent.Scheduler
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.varargs
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.{NonFatal => NF}
 
 /**

--- a/util-core/src/main/scala/com/twitter/util/Credentials.scala
+++ b/util-core/src/main/scala/com/twitter/util/Credentials.scala
@@ -18,7 +18,7 @@ package com.twitter.util
 
 import java.io.{File, IOException}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.io.Source
 import scala.util.parsing.combinator._
 import scala.util.matching.Regex

--- a/util-core/src/main/scala/com/twitter/util/Futures.scala
+++ b/util-core/src/main/scala/com/twitter/util/Futures.scala
@@ -1,12 +1,7 @@
 package com.twitter.util
 
 import java.util.{List => JList, Map => JMap}
-import scala.collection.JavaConverters.{
-  asScalaBufferConverter,
-  mapAsJavaMapConverter,
-  mapAsScalaMapConverter,
-  seqAsJavaListConverter
-}
+import scala.jdk.CollectionConverters._
 
 /**
  * Twitter Future utility methods for ease of use from java

--- a/util-core/src/main/scala/com/twitter/util/Var.scala
+++ b/util-core/src/main/scala/com/twitter/util/Var.scala
@@ -4,9 +4,9 @@ import java.util.concurrent.atomic.{AtomicLong, AtomicReference, AtomicReference
 import java.util.{List => JList}
 import scala.annotation.tailrec
 import scala.collection.compat._
-import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.collection.mutable.Buffer
+import scala.jdk.CollectionConverters._
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.Iterable

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -11,7 +11,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.runtime.NonLocalReturnControl
 import scala.util.Random
 import scala.util.control.ControlThrowable

--- a/util-jvm/src/main/scala/com/twitter/jvm/Allocations.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Allocations.scala
@@ -12,7 +12,7 @@ import javax.management.{
   NotificationListener,
   NotificationEmitter
 }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 private[jvm] object Allocations {

--- a/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Hotspot.scala
@@ -13,7 +13,7 @@ import javax.management.{
   ObjectName,
   RuntimeMBeanException
 }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.reflectiveCalls
 
 class Hotspot extends Jvm {

--- a/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/Jvm.scala
@@ -6,7 +6,7 @@ import com.twitter.util._
 import java.lang.management.ManagementFactory
 import java.util.concurrent.{ConcurrentHashMap, Executors, ScheduledExecutorService, TimeUnit}
 import java.util.logging.{Level, Logger}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 /**

--- a/util-jvm/src/main/scala/com/twitter/jvm/JvmStats.scala
+++ b/util-jvm/src/main/scala/com/twitter/jvm/JvmStats.scala
@@ -3,7 +3,7 @@ package com.twitter.jvm
 import com.twitter.conversions.StringOps._
 import com.twitter.finagle.stats.StatsReceiver
 import java.lang.management.{ManagementFactory, BufferPoolMXBean}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 object JvmStats {

--- a/util-logging/src/main/scala/com/twitter/logging/Logger.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/Logger.scala
@@ -19,7 +19,7 @@ package com.twitter.logging
 import java.util.concurrent.ConcurrentHashMap
 import java.util.{logging => javalog}
 import scala.annotation.varargs
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.Map
 
 class LoggingException(reason: String) extends Exception(reason)

--- a/util-logging/src/main/scala/com/twitter/logging/ThrottledHandler.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/ThrottledHandler.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.{logging => javalog}
 import java.util.function.{Function => JFunction}
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object ThrottledHandler {
 

--- a/util-security/src/main/scala/com/twitter/util/security/X500PrincipalInfo.scala
+++ b/util-security/src/main/scala/com/twitter/util/security/X500PrincipalInfo.scala
@@ -3,7 +3,7 @@ package com.twitter.util.security
 import javax.naming.ldap.{LdapName, Rdn}
 import javax.security.auth.x500.X500Principal
 import com.twitter.util.security.X500PrincipalInfo._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Parses an [[javax.security.auth.x500.X500Principal X500Principal]] into

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/CumulativeGauge.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/CumulativeGauge.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.{ConcurrentHashMap, Executor, ForkJoinPool}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.{Function => JFunction}
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * `CumulativeGauge` provides a [[Gauge gauge]] that is composed of the (addition)

--- a/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
+++ b/util-stats/src/main/scala/com/twitter/finagle/stats/InMemoryStatsReceiver.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.stats
 
 import java.io.PrintStream
 import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.{SortedMap, mutable}
 
 object InMemoryStatsReceiver {

--- a/util-test/src/main/scala/com/twitter/util/testing/ArgumentCapture.scala
+++ b/util-test/src/main/scala/com/twitter/util/testing/ArgumentCapture.scala
@@ -2,7 +2,7 @@ package com.twitter.util.testing
 
 import org.mockito.ArgumentCaptor
 import org.mockito.exceptions.Reporter
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect._
 
 // This file was generated from codegen/util-test/ArgumentCapture.scala.mako

--- a/util-tunable/src/main/scala/com/twitter/util/tunable/JsonTunableMapper.scala
+++ b/util-tunable/src/main/scala/com/twitter/util/tunable/JsonTunableMapper.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.{JsonDeserializer, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.util.{Return, Throw, Try}
 import java.net.URL
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object JsonTunableMapper {
 

--- a/util-tunable/src/main/scala/com/twitter/util/tunable/TunableMap.scala
+++ b/util-tunable/src/main/scala/com/twitter/util/tunable/TunableMap.scala
@@ -3,7 +3,7 @@ package com.twitter.util.tunable
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.BiFunction
 import scala.annotation.varargs
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 /**

--- a/util-tunable/src/test/scala/com/twitter/util/tunable/JsonTunableMapperTest.scala
+++ b/util-tunable/src/test/scala/com/twitter/util/tunable/JsonTunableMapperTest.scala
@@ -7,7 +7,7 @@ import com.twitter.conversions.StorageUnitOps._
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Duration, Return, StorageUnit, Throw}
 import org.scalatest.FunSuite
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 // Used for veryifying custom deserialization
 case class Foo(number: Double)

--- a/util-zk/src/main/scala/com/twitter/zk/AsyncCallbackPromise.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/AsyncCallbackPromise.scala
@@ -2,7 +2,7 @@ package com.twitter.zk
 
 import java.util.{List => JList}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.zookeeper.data.Stat
 import org.apache.zookeeper.{AsyncCallback, KeeperException}

--- a/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZNode.scala
@@ -1,6 +1,6 @@
 package com.twitter.zk
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.{Seq, Set}
 
 import org.apache.zookeeper.common.PathUtils

--- a/util-zk/src/main/scala/com/twitter/zk/ZkClient.scala
+++ b/util-zk/src/main/scala/com/twitter/zk/ZkClient.scala
@@ -1,6 +1,6 @@
 package com.twitter.zk
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.zookeeper.ZooDefs.Ids.CREATOR_ALL_ACL
 import org.apache.zookeeper.data.ACL

--- a/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.zk
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.Set
 
 import org.apache.zookeeper._

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.zk.coordination
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
 import org.scalatest.WordSpec

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with AsyncAssertions {
 


### PR DESCRIPTION
. Use scala.jdk.CollectionConverters instead

on 2.11.x and 2.12.x this is provided by the compat library

Problem

scala.collection.JavaConverters is deprecated

Solution

While it's unclear it's possible deprecated APIs will be removed before scala 4, replace them with scala.jdk.CollectionCompat anyway, even if only to get fewer warnings in the build.

Result

Fewer warnings.