### PR TITLE
add missing type ascription to Logger's apply method

### DIFF
--- a/util-logging/src/main/scala/com/twitter/logging/Logger.scala
+++ b/util-logging/src/main/scala/com/twitter/logging/Logger.scala
@@ -83,7 +83,7 @@ class Logger protected (val name: String, private val wrapped: javalog.Logger) {
   final def apply(level: Level, message: String, items: Any*): Unit = log(level, message, items: _*)
 
   final def apply(level: Level, thrown: Throwable, message: String, items: Any*): Unit =
-    log(level, thrown, message, items)
+    log(level, thrown, message, items: _*)
 
   // convenience methods:
   @varargs

--- a/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
@@ -205,7 +205,9 @@ class LoggerTest extends WordSpec with TempFolder with BeforeAndAfter {
     "log & trace a message with percent signs" in {
       traceLogger(Level.INFO)
       Logger.get("")(Level.INFO, "%i")
+      Logger.get("")(Level.INFO, new Exception(), "%j")
       mustLog("%i")
+      mustLog("%j")
     }
 
     "log a message, with timestamp" in {


### PR DESCRIPTION
Problem

when logging strings that sometimes contain "%" (e.g. URLs with escaped characters), if i also log an exception, i might get a `java.util.UnknownFormatConversionException`. this only happens with the `Logger`'s `apply` method.

Solution

added a missing type ascription to the `apply` method, so it sends the correct items sequence to the `log` method.

Result

fixes added test case (using `apply` with strings that have %)
