### PR TITLE
util-core: improve test coverage for method parse in Duration

### DIFF
--- a/util-core/src/test/scala/com/twitter/util/DurationTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DurationTest.scala
@@ -258,20 +258,20 @@ class DurationTest extends { val ops: Duration.type = Duration } with TimeLikeSp
     }
 
     "reject obvious human impostors" in {
-      intercept[NumberFormatException] {
-        Seq(
-          "",
-          "++1.second",
-          "1. second",
-          "1.milli",
-          "1.s",
-          "10.stardates",
-          "2.minutes 1.second",
-          "98 milliseconds",
-          "98 millisecons",
-          "99.minutes +"
-        ) foreach { s =>
-          Duration.parse(s)
+      Seq(
+        "",
+        "++1.second",
+        "1. second",
+        "1.milli",
+        "1.s",
+        "10.stardates",
+        "2.minutes 1.second",
+        "98 milliseconds",
+        "98 millisecons",
+        "99.minutes +"
+      ) foreach { s =>
+        assertThrows[NumberFormatException] {
+        Duration.parse(s)
         }
       }
     }


### PR DESCRIPTION
Problem

The way it is currently implemented, the test will pass after the first NumberFormatException for the string "". The rest of the strings are therefore not tested.

Solution

Moving the assertion to within the foreach will ensure that all strings in the Seq are tested.

Result

Improves code coverage in parse. Two additional branches in the code are now checked.
