### PR TITLE
Move MonitorTest from WordSpec to FunSuite

### DIFF
--- a/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
@@ -2,7 +2,7 @@ package com.twitter.util
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.WordSpec
+import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
 
 object MonitorTest {
@@ -11,128 +11,124 @@ object MonitorTest {
   }
 }
 
-class MonitorTest extends WordSpec with MockitoSugar {
+class MonitorTest extends FunSuite with MockitoSugar {
   import MonitorTest._
 
-  "Monitor#orElse" should {
-    class MonitorOrElseHelper {
-      val m0, m1, m2 = spy(new MockMonitor())
-      Seq(m0, m1, m2).foreach { m =>
-        when(m.handle(any[Throwable])).thenReturn(true)
-      }
-      val exc = new Exception
-      val m = m0.orElse(m1).orElse(m2)
+  class MonitorOrElseHelper {
+    val m0, m1, m2 = spy(new MockMonitor())
+    Seq(m0, m1, m2).foreach { m =>
+      when(m.handle(any[Throwable])).thenReturn(true)
     }
+    val exc = new Exception
+    val m = m0.orElse(m1).orElse(m2)
+  }
 
-    "stop at first successful handle" in {
-      val h = new MonitorOrElseHelper
-      import h._
+  test("Monitor#orElse should stop at first successful handle") {
+    val h = new MonitorOrElseHelper
+    import h._
 
-      assert(m.handle(exc))
+    assert(m.handle(exc))
 
-      verify(m0).handle(exc)
-      verify(m1, never()).handle(exc)
-      verify(m2, never()).handle(exc)
+    verify(m0).handle(exc)
+    verify(m1, never()).handle(exc)
+    verify(m2, never()).handle(exc)
 
-      when(m0.handle(any[Throwable])).thenReturn(false)
+    when(m0.handle(any[Throwable])).thenReturn(false)
 
-      assert(m.handle(exc))
-      verify(m0, times(2)).handle(exc)
-      verify(m1).handle(exc)
-      verify(m2, never()).handle(exc)
+    assert(m.handle(exc))
+    verify(m0, times(2)).handle(exc)
+    verify(m1).handle(exc)
+    verify(m2, never()).handle(exc)
+  }
+
+  test("Monitor#orElse should fail when no nothing got handled") {
+    val h = new MonitorOrElseHelper
+    import h._
+
+    Seq(m0, m1, m2) foreach { m =>
+      when(m.handle(any[Throwable])).thenReturn(false)
     }
-
-    "fail when no nothing got handled" in {
-      val h = new MonitorOrElseHelper
-      import h._
-
-      Seq(m0, m1, m2) foreach { m =>
-        when(m.handle(any[Throwable])).thenReturn(false)
-      }
-      assert(!m.handle(exc))
-      Seq(m0, m1, m2) foreach { m =>
-        verify(m).handle(exc)
-      }
-    }
-
-    "wrap Monitor exceptions and pass them on" in {
-      val h = new MonitorOrElseHelper
-      import h._
-
-      val rte = new RuntimeException("really bad news")
-      when(m0.handle(any[Throwable])).thenThrow(rte)
-
-      assert(m.handle(exc))
-      verify(m0).handle(exc)
-      verify(m1).handle(MonitorException(exc, rte))
+    assert(!m.handle(exc))
+    Seq(m0, m1, m2) foreach { m =>
+      verify(m).handle(exc)
     }
   }
 
-  "Monitor#andThen" should {
-    class MonitorAndThenHelper {
-      val m0, m1 = spy(new MockMonitor)
-      when(m0.handle(any[Throwable])).thenReturn(true)
-      when(m1.handle(any[Throwable])).thenReturn(true)
-      val m = m0.andThen(m1)
-      val exc = new Exception
-    }
+  test("Monitor#orElse should wrap Monitor exceptions and pass them on") {
+    val h = new MonitorOrElseHelper
+    import h._
 
-    "run all monitors" in {
-      val h = new MonitorAndThenHelper
-      import h._
+    val rte = new RuntimeException("really bad news")
+    when(m0.handle(any[Throwable])).thenThrow(rte)
 
-      when(m0.handle(any[Throwable])).thenReturn(true)
-      when(m1.handle(any[Throwable])).thenReturn(true)
-
-      assert(m.handle(exc))
-      verify(m0).handle(exc)
-      verify(m1).handle(exc)
-    }
-
-    "be succcessful when any underlying monitor is" in {
-      val h = new MonitorAndThenHelper
-      import h._
-
-      when(m0.handle(any[Throwable])).thenReturn(false)
-      assert(m.handle(exc))
-      when(m1.handle(any[Throwable])).thenReturn(false)
-      assert(!m.handle(exc))
-    }
-
-    "wrap Monitor exceptions and pass them on" in {
-      val h = new MonitorAndThenHelper
-      import h._
-
-      val rte = new RuntimeException("really bad news")
-      when(m0.handle(any[Throwable])).thenThrow(rte)
-
-      assert(m.handle(exc))
-      verify(m0).handle(exc)
-      verify(m1).handle(MonitorException(exc, rte))
-    }
-
-    "fail if both monitors throw" in {
-      val h = new MonitorAndThenHelper
-      import h._
-
-      val rte = new RuntimeException("really bad news")
-      when(m0.handle(any[Throwable])).thenThrow(rte)
-      when(m1.handle(any[Throwable])).thenThrow(rte)
-
-      assert(!m.handle(exc))
-    }
+    assert(m.handle(exc))
+    verify(m0).handle(exc)
+    verify(m1).handle(MonitorException(exc, rte))
   }
 
-  "Monitor.get, Monitor.set()" should {
+  class MonitorAndThenHelper {
+    val m0, m1 = spy(new MockMonitor)
+    when(m0.handle(any[Throwable])).thenReturn(true)
+    when(m1.handle(any[Throwable])).thenReturn(true)
+    val m = m0.andThen(m1)
+    val exc = new Exception
+  }
+
+  test("Monitor#andThen should run all monitors") {
+    val h = new MonitorAndThenHelper
+    import h._
+
+    when(m0.handle(any[Throwable])).thenReturn(true)
+    when(m1.handle(any[Throwable])).thenReturn(true)
+
+    assert(m.handle(exc))
+    verify(m0).handle(exc)
+    verify(m1).handle(exc)
+  }
+
+  test("Monitor#andThen should be succcessful when any underlying monitor is") {
+    val h = new MonitorAndThenHelper
+    import h._
+
+    when(m0.handle(any[Throwable])).thenReturn(false)
+    assert(m.handle(exc))
+    when(m1.handle(any[Throwable])).thenReturn(false)
+    assert(!m.handle(exc))
+  }
+
+  test("Monitor#andThen should wrap Monitor exceptions and pass them on") {
+    val h = new MonitorAndThenHelper
+    import h._
+
+    val rte = new RuntimeException("really bad news")
+    when(m0.handle(any[Throwable])).thenThrow(rte)
+
+    assert(m.handle(exc))
+    verify(m0).handle(exc)
+    verify(m1).handle(MonitorException(exc, rte))
+  }
+
+  test("onitor#andThen should fail if both monitors throw") {
+    val h = new MonitorAndThenHelper
+    import h._
+
+    val rte = new RuntimeException("really bad news")
+    when(m0.handle(any[Throwable])).thenThrow(rte)
+    when(m1.handle(any[Throwable])).thenThrow(rte)
+
+    assert(!m.handle(exc))
+  }
+ 
+  test("Monitor.get, Monitor.set() should maintain current monitor") {
     val m = new MockMonitor
-    "maintain current monitor" in Monitor.restoring {
+    Monitor.restoring {
       Monitor.set(m)
       assert(Monitor.get == m)
     }
   }
 
-  "Monitor.getOption, Monitor.setOption" should {
-    "maintain current monitor" in Monitor.restoring {
+  test("Monitor.getOption, Monitor.setOption should maintain current monitor") {
+    Monitor.restoring {
       val mon = new Monitor {
         def handle(cause: Throwable): Boolean = true
       }
@@ -140,8 +136,10 @@ class MonitorTest extends WordSpec with MockitoSugar {
       assert(Monitor.getOption.contains(mon))
       assert(mon == Monitor.get)
     }
+  }
 
-    "setOption of None restores the default" in Monitor.restoring {
+  test("Monitor.getOption, Monitor.setOption should setOption of None restores the default") {
+    Monitor.restoring {
       val mon = new Monitor {
         def handle(cause: Throwable): Boolean = true
       }
@@ -153,11 +151,10 @@ class MonitorTest extends WordSpec with MockitoSugar {
       assert(NullMonitor eq Monitor.get)
     }
   }
-
-  "Monitor.handle" should {
+  
+  test("Monitor.handle should dispatch to current monitor") {
     val m = spy(new MockMonitor)
-
-    "dispatch to current monitor" in Monitor.restoring {
+    Monitor.restoring {
       when(m.handle(any[Throwable])).thenReturn(true)
       val exc = new Exception
       Monitor.set(m)
@@ -166,52 +163,48 @@ class MonitorTest extends WordSpec with MockitoSugar {
     }
   }
 
-  "Monitor.restore" should {
-    "restore current configuration" in {
-      val orig = Monitor.get
-      Monitor.restoring {
-        Monitor.set(mock[Monitor])
-      }
-      assert(Monitor.get == orig)
+  test("Monitor.restore should restore current configuration") {
+    val orig = Monitor.get
+    Monitor.restoring {
+      Monitor.set(mock[Monitor])
+    }
+    assert(Monitor.get == orig)
+  }
+ 
+  class MonitorMkHelper {
+    class E1 extends Exception
+    class E2 extends E1
+    class F1 extends Exception
+
+    var ran = false
+    val m = Monitor.mk {
+      case _: E1 =>
+        ran = true
+        true
     }
   }
 
-  "Monitor.mk" should {
-    class MonitorMkHelper {
-      class E1 extends Exception
-      class E2 extends E1
-      class F1 extends Exception
+  test("Monitor.mk should handle E1") {
+    val h = new MonitorMkHelper
+    import h._
 
-      var ran = false
-      val m = Monitor.mk {
-        case _: E1 =>
-          ran = true
-          true
-      }
-    }
+    assert(m.handle(new E1))
+    assert(ran)
+  }
 
-    "handle E1" in {
-      val h = new MonitorMkHelper
-      import h._
+  test("Monitor.mk should handle E2") {
+    val h = new MonitorMkHelper
+    import h._
 
-      assert(m.handle(new E1))
-      assert(ran)
-    }
+    assert(m.handle(new E2))
+    assert(ran)
+  }
 
-    "handle E2" in {
-      val h = new MonitorMkHelper
-      import h._
+  test("Monitor.mk should handle F1") {
+    val h = new MonitorMkHelper
+    import h._
 
-      assert(m.handle(new E2))
-      assert(ran)
-    }
-
-    "not handle F1" in {
-      val h = new MonitorMkHelper
-      import h._
-
-      assert(!m.handle(new F1))
-      assert(!ran)
-    }
+    assert(!m.handle(new F1))
+    assert(!ran)
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
@@ -108,7 +108,7 @@ class MonitorTest extends FunSuite with MockitoSugar {
     verify(m1).handle(MonitorException(exc, rte))
   }
 
-  test("onitor#andThen should fail if both monitors throw") {
+  test("Monitor#andThen should fail if both monitors throw") {
     val h = new MonitorAndThenHelper
     import h._
 


### PR DESCRIPTION
Problem

In `CONTRIBUTING.md`, it is mentioned that scala tests should use `FunSuite` instead of `WordSpec`. However, originally, the MonitorTest used `WordSpec`.

Solution

Modify the tests in MonitorTest from `WordSpec` into `FunSuite`.

Result

MonitorTest fulfills the testing format `FunSuite`, mentioned in `CONTRIBUTING.md`.
