### PR TITLE
use scalatest non-deprecated names

### DIFF
--- a/util-app-lifecycle/src/test/scala/com/twitter/app/lifecycle/NotifierTest.scala
+++ b/util-app-lifecycle/src/test/scala/com/twitter/app/lifecycle/NotifierTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.app.lifecycle
 
-import org.scalatest.FunSuite
 import Event._
+import org.scalatest.funsuite.AnyFunSuite
 
-class NotifierTest extends FunSuite {
+class NotifierTest extends AnyFunSuite {
 
   test("emits success") {
     var success = false

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -6,9 +6,9 @@ import com.twitter.app.LoadService.Binding
 import com.twitter.conversions.DurationOps._
 import com.twitter.util._
 import java.util.concurrent.ConcurrentLinkedQueue
-import org.scalatest.FunSuite
 import scala.jdk.CollectionConverters._
 import scala.language.reflectiveCalls
+import org.scalatest.funsuite.AnyFunSuite
 
 class TestApp(f: () => Unit) extends App {
   var reason: Option[String] = None
@@ -60,7 +60,7 @@ trait ErrorOnExitApp extends App {
   }
 }
 
-class AppTest extends FunSuite {
+class AppTest extends AnyFunSuite {
   test("App: make sure system.exit called on exception from main") {
     val test1 = new TestApp(() => throw new RuntimeException("simulate main failing"))
 

--- a/util-app/src/test/scala/com/twitter/app/ClassPathTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/ClassPathTest.scala
@@ -2,10 +2,10 @@ package com.twitter.app
 
 import java.net.URLClassLoader
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
-class ClassPathTest extends FunSuite with MockitoSugar {
+class ClassPathTest extends AnyFunSuite with MockitoSugar {
 
   test("Null URL[] URLClassloader") {
     val classLoader = mock[URLClassLoader]

--- a/util-app/src/test/scala/com/twitter/app/FlagTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/FlagTest.scala
@@ -3,10 +3,10 @@ package com.twitter.app
 import com.twitter.app.SolarSystemPlanets._
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Awaitable}
-import org.scalatest.FunSuite
 import scala.collection.mutable
+import org.scalatest.funsuite.AnyFunSuite
 
-class FlagTest extends FunSuite {
+class FlagTest extends AnyFunSuite {
 
   class Ctx(failFastUntilParsed: Boolean = false) {
     val flag = new Flags("test", includeGlobal = false, failFastUntilParsed)

--- a/util-app/src/test/scala/com/twitter/app/FlaggableTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/FlaggableTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.app
 
-import org.scalatest.FunSuite
 import com.twitter.util.{Duration, Time}
 import java.time.LocalTime
+import org.scalatest.funsuite.AnyFunSuite
 
-class FlaggableTest extends FunSuite {
+class FlaggableTest extends AnyFunSuite {
 
   test("Flaggable: parse booleans") {
     assert(Flaggable.ofBoolean.parse("true"))

--- a/util-app/src/test/scala/com/twitter/app/FlagsTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/FlagsTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.app
 
 import com.twitter.util.registry.{Entry, GlobalRegistry, SimpleRegistry}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class FlagsTest extends FunSuite {
+class FlagsTest extends AnyFunSuite {
 
   class Ctx(failFastUntilParsed: Boolean = false) {
     val flag = new Flags("test", includeGlobal = false, failFastUntilParsed)

--- a/util-app/src/test/scala/com/twitter/app/GlobalFlagTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/GlobalFlagTest.scala
@@ -1,12 +1,12 @@
 package com.twitter.app
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 object MyGlobalFlag extends GlobalFlag[String]("a test flag", "a global test flag")
 object MyGlobalFlagNoDefault extends GlobalFlag[Int]("a global test flag with no default")
 object MyGlobalBooleanFlag extends GlobalFlag[Boolean](false, "a boolean flag")
 
-class GlobalFlagTest extends FunSuite {
+class GlobalFlagTest extends AnyFunSuite {
   val flagSet = Set(MyGlobalFlag, MyGlobalBooleanFlag, MyGlobalFlagNoDefault)
 
   test("GlobalFlag.get") {

--- a/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/LoadServiceTest.scala
@@ -11,8 +11,8 @@ import java.util
 import java.util.concurrent.{Callable, CountDownLatch, ExecutorService, Executors}
 import java.util.concurrent.{Future => JFuture}
 import java.util.Random
-import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
 // These traits correspond to files in:
 // util-app/src/test/resources/META-INF/services
@@ -51,7 +51,7 @@ class LoadServiceDeadlockImpl extends LoadServiceDeadlock {
     UsesLoadService.lsd
 }
 
-class LoadServiceTest extends FunSuite with MockitoSugar {
+class LoadServiceTest extends AnyFunSuite with MockitoSugar {
 
   test("LoadService should apply[T] and return a set of instances of T") {
     assert(LoadService[LoadServiceRandomInterface]().nonEmpty)

--- a/util-cache/src/test/scala/com/twitter/cache/AbstractFutureCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/AbstractFutureCacheTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.cache
 
 import com.twitter.util.{Future, Promise}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 // TODO: should also check for races
-abstract class AbstractFutureCacheTest extends FunSuite {
+abstract class AbstractFutureCacheTest extends AnyFunSuite {
 
   def name: String
 

--- a/util-cache/src/test/scala/com/twitter/cache/AbstractLoadingFutureCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/AbstractLoadingFutureCacheTest.scala
@@ -2,9 +2,9 @@ package com.twitter.cache
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-abstract class AbstractLoadingFutureCacheTest extends FunSuite {
+abstract class AbstractLoadingFutureCacheTest extends AnyFunSuite {
   // NB we can't reuse AbstractFutureCacheTest since
   // loading cache semantics are sufficiently unique
   // to merit distinct tests.

--- a/util-cache/src/test/scala/com/twitter/cache/EvictingCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/EvictingCacheTest.scala
@@ -3,10 +3,10 @@ package com.twitter.cache
 import com.twitter.util.{Promise, Future}
 import java.util.concurrent.ConcurrentHashMap
 import org.mockito.Mockito.{verify, never}
-import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
-class EvictingCacheTest extends FunSuite with MockitoSugar {
+class EvictingCacheTest extends AnyFunSuite with MockitoSugar {
   test("EvictingCache should evict on failed futures for set") {
     val cache = mock[FutureCache[String, String]]
     val fCache = new EvictingCache(cache)

--- a/util-cache/src/test/scala/com/twitter/cache/LazilyEvictingCacheTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/LazilyEvictingCacheTest.scala
@@ -5,10 +5,10 @@ import com.twitter.cache.caffeine.LoadingFutureCache
 import com.twitter.util.{Await, Future, Promise}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{never, verify, when}
-import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
-class LazilyEvictingCacheTest extends FunSuite with MockitoSugar {
+class LazilyEvictingCacheTest extends AnyFunSuite with MockitoSugar {
   private val explodingCacheLoader =
     new CacheLoader[String, Future[String]] {
       def load(k: String): Future[String] =

--- a/util-cache/src/test/scala/com/twitter/cache/RefreshTest.scala
+++ b/util-cache/src/test/scala/com/twitter/cache/RefreshTest.scala
@@ -5,8 +5,9 @@ import com.twitter.util.{Await, Future, Promise, Time}
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
-class RefreshTest extends FunSuite with MockitoSugar {
+class RefreshTest extends AnyFunSuite with MockitoSugar {
 
   class Ctx {
     val provider = mock[() => Future[Int]]

--- a/util-codec/src/test/scala/com/twitter/util/StringEncoderTest.scala
+++ b/util-codec/src/test/scala/com/twitter/util/StringEncoderTest.scala
@@ -18,9 +18,9 @@ package com.twitter.util
 
 import java.lang.StringBuilder
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class StringEncoderTest extends WordSpec {
+class StringEncoderTest extends AnyWordSpec {
   val longString =
     "A string that is really really really really really really long and has more than 76 characters"
   val result =
@@ -35,7 +35,7 @@ class StringEncoderTest extends WordSpec {
   }
 }
 
-class Base64StringEncoderTest extends WordSpec {
+class Base64StringEncoderTest extends AnyWordSpec {
   val urlUnsafeBytes = Array(-1.toByte, -32.toByte)
   val resultUnsafe = "/+A"
   val resultSafe = "_-A"
@@ -55,7 +55,7 @@ class Base64StringEncoderTest extends WordSpec {
   }
 }
 
-class GZIPStringEncoderTest extends WordSpec {
+class GZIPStringEncoderTest extends AnyWordSpec {
   "a gzip string encoder" should {
     val gse = new GZIPStringEncoder {}
     "properly encode and decode strings" in {

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncMeterTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncMeterTest.scala
@@ -3,9 +3,9 @@ package com.twitter.concurrent
 import com.twitter.util._
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.{RejectedExecutionException, CancellationException}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class AsyncMeterTest extends FunSuite {
+class AsyncMeterTest extends AnyFunSuite {
   import AsyncMeter._
 
   // Workaround methods for dealing with Scala compiler warnings:

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncMutexTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncMutexTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.concurrent
 
-import org.scalatest.FlatSpec
 import com.twitter.util.Await
+import org.scalatest.flatspec.AnyFlatSpec
 
-class AsyncMutexTest extends FlatSpec {
+class AsyncMutexTest extends AnyFlatSpec {
   "AsyncMutex" should "admit only one operation at a time" in {
     val m = new AsyncMutex
 

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncQueueTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncQueueTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.concurrent
 
 import com.twitter.util.{Await, Awaitable, Duration, Return, Throw}
-import org.scalatest.FunSuite
 import scala.collection.immutable.Queue
+import org.scalatest.funsuite.AnyFunSuite
 
-class AsyncQueueTest extends FunSuite {
+class AsyncQueueTest extends AnyFunSuite {
 
   private def await[T](t: Awaitable[T]): T = Await.result(t, Duration.fromSeconds(5))
 

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncSemaphoreTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncSemaphoreTest.scala
@@ -3,11 +3,11 @@ package com.twitter.concurrent
 import com.twitter.conversions.DurationOps._
 import com.twitter.util._
 import java.util.concurrent.{ConcurrentLinkedQueue, RejectedExecutionException, CountDownLatch}
-import org.scalatest.fixture.FunSpec
 import scala.collection.mutable
 import org.scalatest.Outcome
+import org.scalatest.funspec.FixtureAnyFunSpec
 
-class AsyncSemaphoreTest extends FunSpec {
+class AsyncSemaphoreTest extends FixtureAnyFunSpec {
   class AsyncSemaphoreHelper(
     val sem: AsyncSemaphore,
     var count: Int,

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -3,10 +3,10 @@ package com.twitter.concurrent
 import com.twitter.conversions.DurationOps._
 import com.twitter.util._
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class AsyncStreamTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class AsyncStreamTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   import AsyncStream.{mk, of}
   import AsyncStreamTest._
 

--- a/util-core/src/test/scala/com/twitter/concurrent/BrokerTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/BrokerTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.concurrent
 
 import com.twitter.util.{Await, Return, ObjectSizeCalculator}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class BrokerTest extends WordSpec {
+class BrokerTest extends AnyWordSpec {
   "Broker" should {
     "send data (send, recv)" in {
       val br = new Broker[Int]

--- a/util-core/src/test/scala/com/twitter/concurrent/OfferTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/OfferTest.scala
@@ -3,10 +3,10 @@ package com.twitter.concurrent
 import scala.util.Random
 
 import org.mockito.Mockito._
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, MockTimer, Promise, Return, Time}
+import org.scalatest.wordspec.AnyWordSpec
 
 class SimpleOffer[T](var futures: Stream[Future[Tx[T]]]) extends Offer[T] {
   def this(fut: Future[Tx[T]]) = this(Stream.continually(fut))
@@ -19,7 +19,7 @@ class SimpleOffer[T](var futures: Stream[Future[Tx[T]]]) extends Offer[T] {
   }
 }
 
-class OfferTest extends WordSpec with MockitoSugar {
+class OfferTest extends AnyWordSpec with MockitoSugar {
 
   def await[A](f: Future[A]): A = Await.result(f, 2.seconds)
 

--- a/util-core/src/test/scala/com/twitter/concurrent/OnceTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/OnceTest.scala
@@ -2,9 +2,9 @@ package com.twitter.concurrent
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Promise, Await}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class OnceTest extends FunSuite {
+class OnceTest extends AnyFunSuite {
   test("Once.apply should only be applied once") {
     var x = 0
     val once = Once { x += 1 }

--- a/util-core/src/test/scala/com/twitter/concurrent/PeriodTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/PeriodTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.concurrent
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PeriodTest extends FunSuite {
+class PeriodTest extends AnyFunSuite {
   test("Period#numPeriods should behave reasonably") {
     val period = new Period(1.second)
     val dur = 1.second

--- a/util-core/src/test/scala/com/twitter/concurrent/SchedulerTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SchedulerTest.scala
@@ -4,10 +4,11 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util._
 import java.util.concurrent.{Executors, TimeUnit}
 import java.util.logging.{Handler, Level, LogRecord}
-import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-abstract class LocalSchedulerTest(lifo: Boolean) extends FunSuite with Matchers {
+abstract class LocalSchedulerTest(lifo: Boolean) extends AnyFunSuite with Matchers {
   private val scheduler = new LocalScheduler(lifo)
   def submit(f: => Unit): Unit =
     scheduler.submit(new Runnable {
@@ -156,7 +157,7 @@ class LocalSchedulerFifoTest extends LocalSchedulerTest(false)
 
 class LocalSchedulerLifoTest extends LocalSchedulerTest(true)
 
-class ThreadPoolSchedulerTest extends FunSuite with Eventually with IntegrationPatience {
+class ThreadPoolSchedulerTest extends AnyFunSuite with Eventually with IntegrationPatience {
   test("works") {
     val p = new Promise[Unit]
     val scheduler = new ThreadPoolScheduler("test")

--- a/util-core/src/test/scala/com/twitter/concurrent/SerializedTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SerializedTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.concurrent
 
 import java.util.concurrent.CountDownLatch
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class SerializedTest extends WordSpec with Serialized {
+class SerializedTest extends AnyWordSpec with Serialized {
   "Serialized" should {
     "runs blocks, one at a time, in the order received" in {
       val t1CallsSerializedFirst = new CountDownLatch(1)

--- a/util-core/src/test/scala/com/twitter/concurrent/SpoolSourceTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SpoolSourceTest.scala
@@ -2,9 +2,9 @@ package com.twitter.concurrent
 
 import com.twitter.util.{Return, Await}
 import java.util.concurrent.atomic.AtomicInteger
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class SpoolSourceTest extends WordSpec {
+class SpoolSourceTest extends AnyWordSpec {
   "SpoolSource" should {
     class SpoolSourceHelper {
       val source = new SpoolSource[Int]

--- a/util-core/src/test/scala/com/twitter/concurrent/SpoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/SpoolTest.scala
@@ -5,11 +5,11 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, Promise, Return, Throw}
 import java.io.EOFException
 import org.scalacheck.Arbitrary
-import org.scalatest.WordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable.ArrayBuffer
+import org.scalatest.wordspec.AnyWordSpec
 
-class SpoolTest extends WordSpec with ScalaCheckDrivenPropertyChecks {
+class SpoolTest extends AnyWordSpec with ScalaCheckDrivenPropertyChecks {
 
   def await[A](f: Future[A]): A = Await.result(f, 2.seconds)
 

--- a/util-core/src/test/scala/com/twitter/concurrent/TxTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/TxTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.concurrent
 
-import org.scalatest.WordSpec
 import com.twitter.util.Return
+import org.scalatest.wordspec.AnyWordSpec
 
-class TxTest extends WordSpec {
+class TxTest extends AnyWordSpec {
   "Tx.twoParty" should {
     "commit when everything goes dandy" in {
       val (stx, rtx) = Tx.twoParty(123)

--- a/util-core/src/test/scala/com/twitter/conversions/DurationOpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/DurationOpsTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.conversions
 
 import com.twitter.util.Duration
-import org.scalatest.FunSuite
 import com.twitter.conversions.DurationOps._
+import org.scalatest.funsuite.AnyFunSuite
 
-class DurationOpsTest extends FunSuite {
+class DurationOpsTest extends AnyFunSuite {
   test("converts Duration.Zero") {
     assert(0.seconds eq Duration.Zero)
     assert(0.milliseconds eq Duration.Zero)

--- a/util-core/src/test/scala/com/twitter/conversions/OpsTogetherTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/OpsTogetherTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.conversions
 
 import com.twitter.util.{Duration, StorageUnit}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class OpsTogetherTest extends FunSuite {
+class OpsTogetherTest extends AnyFunSuite {
   test("multiple wildcard imports") {
     import com.twitter.conversions.DurationOps._
     import com.twitter.conversions.PercentOps._

--- a/util-core/src/test/scala/com/twitter/conversions/PercentOpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/PercentOpsTest.scala
@@ -3,10 +3,10 @@ package com.twitter.conversions
 import com.twitter.conversions.PercentOps._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class PercentOpsTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class PercentOpsTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 
   private[this] val Precision = 0.0000000001
 

--- a/util-core/src/test/scala/com/twitter/conversions/StorageUnitOpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/StorageUnitOpsTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.conversions
 
 import com.twitter.util.StorageUnit
-import org.scalatest.FunSuite
 import com.twitter.conversions.StorageUnitOps._
+import org.scalatest.funsuite.AnyFunSuite
 
-class StorageUnitOpsTest extends FunSuite {
+class StorageUnitOpsTest extends AnyFunSuite {
 
   test("converts") {
     assert(StorageUnit.fromBytes(1) == 1.byte)

--- a/util-core/src/test/scala/com/twitter/conversions/U64OpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/U64OpsTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.conversions
 
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class U64OpsTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class U64OpsTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   import com.twitter.conversions.U64Ops._
 
   test("toU64HextString") {

--- a/util-core/src/test/scala/com/twitter/io/ActivitySourceTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ActivitySourceTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.io
 
 import com.twitter.util.Activity
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ActivitySourceTest extends FunSuite {
+class ActivitySourceTest extends AnyFunSuite {
 
   val ok: ActivitySource[String] = new ActivitySource[String] {
     def get(varName: String) = Activity.value(varName)

--- a/util-core/src/test/scala/com/twitter/io/BufByteWriterTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufByteWriterTest.scala
@@ -2,10 +2,10 @@ package com.twitter.io
 
 import java.lang.{Double => JDouble, Float => JFloat}
 import java.nio.charset.StandardCharsets
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-final class BufByteWriterTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+final class BufByteWriterTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   import ByteWriter.OverflowException
 
   private[this] def assertIndex(bw: ByteWriter, index: Int): Unit = bw match {

--- a/util-core/src/test/scala/com/twitter/io/BufInputStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufInputStreamTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.io
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class BufInputStreamTest extends FunSuite {
+class BufInputStreamTest extends AnyFunSuite {
   private[this] val fileString =
     "Test_All_Tests\nTest_java_io_BufferedInputStream\nTest_java_io_BufferedOutputStream\nTest_ByteArrayInputStream\nTest_java_io_ByteArrayOutputStream\nTest_java_io_DataInputStream\n"
   private[this] val fileBuf = Buf.ByteArray.Owned(fileString.getBytes)

--- a/util-core/src/test/scala/com/twitter/io/BufReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufReaderTest.scala
@@ -4,11 +4,11 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.conversions.StorageUnitOps._
 import com.twitter.util.{Await, Future}
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.annotation.tailrec
+import org.scalatest.funsuite.AnyFunSuite
 
-class BufReaderTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class BufReaderTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 
   private def await[A](f: Future[A]): A = Await.result(f, 5.seconds)
 

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -5,16 +5,16 @@ import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{StandardCharsets => JChar}
 import java.util.Arrays
 import org.scalacheck.{Arbitrary, Gen, Prop}
-import org.scalatest.FunSuite
 import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatestplus.scalacheck.Checkers
 import scala.collection.mutable
 import java.nio.charset.Charset
+import org.scalatest.funsuite.AnyFunSuite
 
 class BufTest
-    extends FunSuite
+    extends AnyFunSuite
     with MockitoSugar
     with ScalaCheckDrivenPropertyChecks
     with Checkers

--- a/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ByteReaderTest.scala
@@ -3,10 +3,10 @@ package com.twitter.io
 import java.lang.{Double => JDouble, Float => JFloat}
 import java.nio.charset.StandardCharsets
 import org.scalacheck.Gen
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class ByteReaderTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class ByteReaderTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   import ByteReader._
 
   def readerWith(bytes: Byte*): ByteReader = ByteReader(Buf.ByteArray.Owned(bytes.toArray))

--- a/util-core/src/test/scala/com/twitter/io/CachingActivitySourceTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/CachingActivitySourceTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.io
 
 import com.twitter.util.Activity
-import org.scalatest.FunSuite
 import scala.util.Random
+import org.scalatest.funsuite.AnyFunSuite
 
-class CachingActivitySourceTest extends FunSuite {
+class CachingActivitySourceTest extends AnyFunSuite {
 
   test("CachingActivitySource") {
     val cache = new CachingActivitySource[String](new ActivitySource[String] {

--- a/util-core/src/test/scala/com/twitter/io/ClassLoaderActivitySourceTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ClassLoaderActivitySourceTest.scala
@@ -2,9 +2,9 @@ package com.twitter.io
 
 import com.twitter.util.FuturePool
 import java.io.ByteArrayInputStream
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ClassLoaderActivitySourceTest extends FunSuite {
+class ClassLoaderActivitySourceTest extends AnyFunSuite {
 
   test("ClassLoaderActivitySource") {
     val classLoader = new ClassLoader() {

--- a/util-core/src/test/scala/com/twitter/io/FilePollingActivitySourceTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/FilePollingActivitySourceTest.scala
@@ -2,10 +2,11 @@ package com.twitter.io
 
 import com.twitter.util.{Activity, FuturePool, MockTimer, Time}
 import java.io.File
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
 import scala.util.Random
+import org.scalatest.funsuite.AnyFunSuite
 
-class FilePollingActivitySourceTest extends FunSuite with BeforeAndAfter {
+class FilePollingActivitySourceTest extends AnyFunSuite with BeforeAndAfter {
 
   def writeToTempFile(s: String): Unit = {
     val printer = new java.io.PrintWriter(new File(tempFile))

--- a/util-core/src/test/scala/com/twitter/io/FilesTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/FilesTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.io
 
 import java.io.File
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class FilesTest extends WordSpec with TempFolder {
+class FilesTest extends AnyWordSpec with TempFolder {
   "Files" should {
 
     "delete" in withTempFolder {

--- a/util-core/src/test/scala/com/twitter/io/InputStreamReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/InputStreamReaderTest.scala
@@ -4,9 +4,9 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, FuturePool}
 import java.io.ByteArrayInputStream
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class InputStreamReaderTest extends FunSuite {
+class InputStreamReaderTest extends AnyFunSuite {
   def arr(i: Int, j: Int): Array[Byte] = Array.range(i, j).map(_.toByte)
   def buf(i: Int, j: Int): Buf = Buf.ByteArray.Owned(arr(i, j))
 

--- a/util-core/src/test/scala/com/twitter/io/IteratorReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/IteratorReaderTest.scala
@@ -2,10 +2,10 @@ package com.twitter.io
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future}
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.Checkers
+import org.scalatest.funsuite.AnyFunSuite
 
-class IteratorReaderTest extends FunSuite with Checkers {
+class IteratorReaderTest extends AnyFunSuite with Checkers {
 
   private def await[A](f: Future[A]): A = Await.result(f, 5.seconds)
 

--- a/util-core/src/test/scala/com/twitter/io/PipeTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/PipeTest.scala
@@ -3,10 +3,11 @@ package com.twitter.io
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, MockTimer, Return, Time}
 import java.io.ByteArrayOutputStream
-import org.scalatest.{FunSuite, Matchers}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class PipeTest extends FunSuite with Matchers with ScalaCheckDrivenPropertyChecks {
+class PipeTest extends AnyFunSuite with Matchers with ScalaCheckDrivenPropertyChecks {
 
   private def await[A](f: Future[A]): A = Await.result(f, 5.seconds)
 

--- a/util-core/src/test/scala/com/twitter/io/ReaderSemanticsTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ReaderSemanticsTest.scala
@@ -5,10 +5,10 @@ import com.twitter.conversions.StorageUnitOps._
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Future, Return, Await, Throw}
 import java.io.ByteArrayInputStream
-import org.scalatest.FunSuite
 import scala.util.Random
+import org.scalatest.funsuite.AnyFunSuite
 
-abstract class ReaderSemanticsTest[A] extends FunSuite {
+abstract class ReaderSemanticsTest[A] extends AnyFunSuite {
   def createReader(): Reader[A]
 
   def loopAndCheck(reader: Reader[A], onClose: Future[StreamTermination]): Future[Unit] = {

--- a/util-core/src/test/scala/com/twitter/io/ReaderTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/ReaderTest.scala
@@ -10,12 +10,13 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.mockito.Mockito._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.{FunSuite, Matchers}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable.ArrayBuffer
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 class ReaderTest
-    extends FunSuite
+    extends AnyFunSuite
     with ScalaCheckDrivenPropertyChecks
     with Matchers
     with Eventually

--- a/util-core/src/test/scala/com/twitter/io/StreamIOTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/StreamIOTest.scala
@@ -2,9 +2,9 @@ package com.twitter.io
 
 import scala.util.Random
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class StreamIOTest extends WordSpec {
+class StreamIOTest extends AnyWordSpec {
   "StreamIO.copy" should {
     "copy the entire stream" in {
       val buf = new Array[Byte](2048)

--- a/util-core/src/test/scala/com/twitter/io/TempDirectoryTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/TempDirectoryTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.io
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class TempDirectoryTest extends WordSpec {
+class TempDirectoryTest extends AnyWordSpec {
 
   "TempDirectory" should {
 

--- a/util-core/src/test/scala/com/twitter/io/TempFileTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/TempFileTest.scala
@@ -2,9 +2,9 @@ package com.twitter.io
 
 import java.io.{ByteArrayInputStream, DataInputStream}
 import java.util.Arrays
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class TempFileTest extends WordSpec {
+class TempFileTest extends AnyWordSpec {
 
   "TempFile" should {
 

--- a/util-core/src/test/scala/com/twitter/io/WriterTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/WriterTest.scala
@@ -3,9 +3,10 @@ package com.twitter.io
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, Promise}
 import java.io.{ByteArrayOutputStream, OutputStream}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class WriterTest extends FunSuite with Matchers {
+class WriterTest extends AnyFunSuite with Matchers {
 
   private def await[A](f: Future[A]): A = Await.result(f, 5.seconds)
 

--- a/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ActivityTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util
 
 import java.util.concurrent.atomic.AtomicReference
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ActivityTest extends FunSuite {
+class ActivityTest extends AnyFunSuite {
   test("Activity#flatMap") {
     val v = Var(Activity.Pending: Activity.State[Int])
     val ref = new AtomicReference[Seq[Activity.State[Int]]]

--- a/util-core/src/test/scala/com/twitter/util/Base64LongTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/Base64LongTest.scala
@@ -4,8 +4,8 @@ import com.twitter.util.Base64Long.{fromBase64, StandardBase64Alphabet, toBase64
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
 object Base64LongTest {
   private val BoundaryValues =
@@ -52,7 +52,7 @@ object Base64LongTest {
   }
 }
 
-class Base64LongTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class Base64LongTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   import Base64LongTest._
 
   private[this] def forAllLongs(f: (Alphabet, Long) => Unit): Unit = {

--- a/util-core/src/test/scala/com/twitter/util/CancellableTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/CancellableTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class CancellableTest extends FunSuite {
+class CancellableTest extends AnyFunSuite {
 
   test("Cancellable.nil is always cancelled") {
     assert(!Cancellable.nil.isCancelled)

--- a/util-core/src/test/scala/com/twitter/util/ClosableOnceTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ClosableOnceTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ClosableOnceTest extends FunSuite {
+class ClosableOnceTest extends AnyFunSuite {
 
   private def ready[T <: Awaitable[_]](awaitable: T): T =
     Await.ready(awaitable, 10.seconds)

--- a/util-core/src/test/scala/com/twitter/util/ClosableTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ClosableTest.scala
@@ -1,11 +1,11 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import scala.language.reflectiveCalls
+import org.scalatest.funsuite.AnyFunSuite
 
-class ClosableTest extends FunSuite with Eventually with IntegrationPatience {
+class ClosableTest extends AnyFunSuite with Eventually with IntegrationPatience {
 
   // Workaround methods for dealing with Scala compiler warnings:
   //

--- a/util-core/src/test/scala/com/twitter/util/CloseAwaitablyTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/CloseAwaitablyTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class CloseAwaitablyTest extends FunSuite {
+class CloseAwaitablyTest extends AnyFunSuite {
   class Context extends Closable with CloseAwaitably {
     val p: Promise[Unit] = new Promise[Unit]
     var n: Int = 0

--- a/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
@@ -1,8 +1,9 @@
 package com.twitter.util
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ConfigTest extends WordSpec with Matchers {
+class ConfigTest extends AnyWordSpec with Matchers {
   import Config._
 
   "Config" should {

--- a/util-core/src/test/scala/com/twitter/util/DiffTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DiffTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.util
 
-import org.scalatest.FunSuite
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class DiffTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class DiffTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   val f: Int => String = _.toString
 
   test("Diffable.ofSet") {

--- a/util-core/src/test/scala/com/twitter/util/EventTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/EventTest.scala
@@ -2,10 +2,10 @@ package com.twitter.util
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{CountDownLatch, Executors}
-import org.scalatest.FunSuite
 import scala.collection.mutable
+import org.scalatest.funsuite.AnyFunSuite
 
-class EventTest extends FunSuite {
+class EventTest extends AnyFunSuite {
 
   test("pub/sub while active") {
     val e = Event[Int]()

--- a/util-core/src/test/scala/com/twitter/util/FutureOfferTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureOfferTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.concurrent
 
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import com.twitter.util.{Promise, Return}
+import org.scalatest.wordspec.AnyWordSpec
 
-class FutureOfferTest extends WordSpec with MockitoSugar {
+class FutureOfferTest extends AnyWordSpec with MockitoSugar {
   "Future.toOffer" should {
     "activate when future is satisfied (poll)" in {
       val p = new Promise[Int]

--- a/util-core/src/test/scala/com/twitter/util/FuturePoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FuturePoolTest.scala
@@ -2,13 +2,13 @@ package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.{Future => JFuture, _}
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
 import scala.runtime.NonLocalReturnControl
 import scala.util.control.NonFatal
+import org.scalatest.funsuite.AnyFunSuite
 
-class FuturePoolTest extends FunSuite with Eventually {
+class FuturePoolTest extends AnyFunSuite with Eventually {
 
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = scaled(Span(5, Millis)))

--- a/util-core/src/test/scala/com/twitter/util/FutureTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/FutureTest.scala
@@ -8,7 +8,6 @@ import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.jdk.CollectionConverters._
@@ -16,6 +15,7 @@ import scala.runtime.NonLocalReturnControl
 import scala.util.Random
 import scala.util.control.ControlThrowable
 import scala.util.control.NonFatal
+import org.scalatest.wordspec.AnyWordSpec
 
 private object FutureTest {
   def await[A](f: Future[A], timeout: Duration = 5.seconds): A =
@@ -38,7 +38,7 @@ private object FutureTest {
   }
 }
 
-class FutureTest extends WordSpec with MockitoSugar with ScalaCheckDrivenPropertyChecks {
+class FutureTest extends AnyWordSpec with MockitoSugar with ScalaCheckDrivenPropertyChecks {
   import FutureTest._
 
   implicit class FutureMatcher[A](future: Future[A]) {

--- a/util-core/src/test/scala/com/twitter/util/LastWriteWinsQueueTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/LastWriteWinsQueueTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class LastWriteWinsQueueTest extends WordSpec {
+class LastWriteWinsQueueTest extends AnyWordSpec {
   "LastWriteWinsQueue" should {
     val queue = new LastWriteWinsQueue[String]
 

--- a/util-core/src/test/scala/com/twitter/util/LocalTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/LocalTest.scala
@@ -2,10 +2,10 @@ package com.twitter.util
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class LocalTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class LocalTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   test("Local: should be undefined by default") {
     val local = new Local[Int]
     assert(local() == None)

--- a/util-core/src/test/scala/com/twitter/util/MemoizeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/MemoizeTest.scala
@@ -4,9 +4,9 @@ import com.twitter.conversions.DurationOps._
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{TimeUnit, CountDownLatch => JavaCountDownLatch}
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class MemoizeTest extends FunSuite {
+class MemoizeTest extends AnyFunSuite {
   test("Memoize.apply: only runs the function once for the same input") {
     // mockito can't spy anonymous classes,
     // and this was the simplest approach i could come up with.

--- a/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/MonitorTest.scala
@@ -2,8 +2,8 @@ package com.twitter.util
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
 object MonitorTest {
   class MockMonitor extends Monitor {
@@ -11,7 +11,7 @@ object MonitorTest {
   }
 }
 
-class MonitorTest extends FunSuite with MockitoSugar {
+class MonitorTest extends AnyFunSuite with MockitoSugar {
   import MonitorTest._
 
   class MonitorOrElseHelper {

--- a/util-core/src/test/scala/com/twitter/util/NetUtilTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/NetUtilTest.scala
@@ -2,9 +2,9 @@ package com.twitter.util
 
 import java.net.InetAddress
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class NetUtilTest extends WordSpec {
+class NetUtilTest extends AnyWordSpec {
   "NetUtil" should {
     "isIpv4Address" in {
       for (i <- 0.to(255)) {

--- a/util-core/src/test/scala/com/twitter/util/PoolTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PoolTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.WordSpec
 import scala.collection.mutable
+import org.scalatest.wordspec.AnyWordSpec
 
-class PoolTest extends WordSpec {
+class PoolTest extends AnyWordSpec {
 
   private[this] def await[T](f: Awaitable[T]): T =
     Await.result(f, 2.seconds)

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PromiseTest extends FunSuite {
+class PromiseTest extends AnyFunSuite {
 
   test("Promise.detach should not detach other attached promises") {
     val p = new Promise[Unit]

--- a/util-core/src/test/scala/com/twitter/util/SlowProbeProxyTimerTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/SlowProbeProxyTimerTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.FunSuite
 import scala.collection.mutable
+import org.scalatest.funsuite.AnyFunSuite
 
-class SlowProbeProxyTimerTest extends FunSuite {
+class SlowProbeProxyTimerTest extends AnyFunSuite {
 
   private type Task = () => Unit
   private val NullTask = new TimerTask { def cancel(): Unit = () }

--- a/util-core/src/test/scala/com/twitter/util/StateMachineTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/StateMachineTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class StateMachineTest extends WordSpec {
+class StateMachineTest extends AnyWordSpec {
   "StateMachine" should {
     class StateMachineHelper {
       class Machine extends StateMachine {

--- a/util-core/src/test/scala/com/twitter/util/StorageUnitTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/StorageUnitTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.util
 
-import org.scalatest.FunSuite
 
 import com.twitter.conversions.StorageUnitOps._
+import org.scalatest.funsuite.AnyFunSuite
 
-class StorageUnitTest extends FunSuite {
+class StorageUnitTest extends AnyFunSuite {
   test("StorageUnit: should convert whole numbers into storage units (back and forth)") {
     assert(1.byte.inBytes == 1)
     assert(1.kilobyte.inBytes == 1024)

--- a/util-core/src/test/scala/com/twitter/util/StringConversionsTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/StringConversionsTest.scala
@@ -17,9 +17,9 @@
 package com.twitter.util
 
 import com.twitter.conversions.StringOps._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class StringConversionsTest extends FunSuite {
+class StringConversionsTest extends AnyFunSuite {
 
   test("string#quoteC") {
     assert("nothing".quoteC == "nothing")

--- a/util-core/src/test/scala/com/twitter/util/ThrowablesTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ThrowablesTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ThrowablesTest extends FunSuite {
+class ThrowablesTest extends AnyFunSuite {
   test("Throwables.mkString: flatten non-nested exception") {
     val t = new Throwable
     assert(Throwables.mkString(t) == Seq(t.getClass.getName))

--- a/util-core/src/test/scala/com/twitter/util/TimeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimeTest.scala
@@ -4,13 +4,13 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 import java.util.{Locale, TimeZone}
 import java.util.concurrent.TimeUnit
 
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import com.twitter.conversions.DurationOps._
+import org.scalatest.wordspec.AnyWordSpec
 
-trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with ScalaCheckDrivenPropertyChecks {
+trait TimeLikeSpec[T <: TimeLike[T]] extends AnyWordSpec with ScalaCheckDrivenPropertyChecks {
   val ops: TimeLikeOps[T]
   import ops._
 
@@ -371,7 +371,7 @@ trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with ScalaCheckDrivenPrope
   }
 }
 
-class TimeFormatTest extends WordSpec {
+class TimeFormatTest extends AnyWordSpec {
   "TimeFormat" should {
     "format correctly with non US locale" in {
       val locale = Locale.GERMAN

--- a/util-core/src/test/scala/com/twitter/util/TimerTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimerTest.scala
@@ -6,11 +6,11 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, verify, when}
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.{IntegrationPatience, Eventually}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
-class TimerTest extends FunSuite with MockitoSugar with Eventually with IntegrationPatience {
+class TimerTest extends AnyFunSuite with MockitoSugar with Eventually with IntegrationPatience {
 
   private def testTimerRunsWithLocals(timer: Timer): Unit = {
     val timerLocal = new AtomicInteger(0)

--- a/util-core/src/test/scala/com/twitter/util/TokenBucketTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TokenBucketTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util
 
-import org.scalatest.FunSuite
 import com.twitter.conversions.DurationOps._
+import org.scalatest.funsuite.AnyFunSuite
 
-class TokenBucketTest extends FunSuite {
+class TokenBucketTest extends AnyFunSuite {
   test("a leaky bucket is leaky") {
     Time.withCurrentTimeFrozen { tc =>
       val b = TokenBucket.newLeakyBucket(3.seconds, 0, Stopwatch.timeMillis)

--- a/util-core/src/test/scala/com/twitter/util/TryTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TryTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TryTest extends FunSuite {
+class TryTest extends AnyFunSuite {
   class MyException extends Exception
   val e: Exception = new Exception("this is an exception")
 

--- a/util-core/src/test/scala/com/twitter/util/TwitterDateFormatTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TwitterDateFormatTest.scala
@@ -2,9 +2,9 @@ package com.twitter.util
 
 import java.util.Locale
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class TwitterDateFormatTest extends WordSpec {
+class TwitterDateFormatTest extends AnyWordSpec {
   "TwitterDateFormat" should {
     "disallow Y without w" in {
       intercept[IllegalArgumentException] {

--- a/util-core/src/test/scala/com/twitter/util/VarTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/VarTest.scala
@@ -2,11 +2,11 @@ package com.twitter.util
 
 import java.util.concurrent.atomic.AtomicReference
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable
+import org.scalatest.funsuite.AnyFunSuite
 
-class VarTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class VarTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 
   // Workaround methods for dealing with Scala compiler warnings:
   //

--- a/util-core/src/test/scala/com/twitter/util/WaitQueueTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/WaitQueueTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.util
 
 import org.scalacheck.Gen
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class WaitQueueTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class WaitQueueTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 
   private class EmptyK[A] extends Promise.K[A] {
     protected[util] def depth: Short = 0

--- a/util-core/src/test/scala/com/twitter/util/WindowedAdderTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/WindowedAdderTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class WindowedAdderTest extends FunSuite {
+class WindowedAdderTest extends AnyFunSuite {
   private def newAdder() = WindowedAdder(3 * 1000, 3, Stopwatch.timeMillis)
 
   test("sums things up when time stands still") {

--- a/util-hashing/src/test/scala/com/twitter/hashing/ConsistentHashingDistributorTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/ConsistentHashingDistributorTest.scala
@@ -1,14 +1,14 @@
 package com.twitter.hashing
 
 import org.scalacheck.Gen
-import org.scalatest.WordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable
 import java.io.{BufferedReader, InputStreamReader}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.security.MessageDigest
+import org.scalatest.wordspec.AnyWordSpec
 
-class ConsistentHashingDistributorTest extends WordSpec with ScalaCheckDrivenPropertyChecks {
+class ConsistentHashingDistributorTest extends AnyWordSpec with ScalaCheckDrivenPropertyChecks {
   "KetamaDistributor" should {
     val nodes = Seq(
       HashNode("10.0.1.1", 600, 1),

--- a/util-hashing/src/test/scala/com/twitter/hashing/DiagnosticsTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/DiagnosticsTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.hashing
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class DiagnosticsTest extends WordSpec {
+class DiagnosticsTest extends AnyWordSpec {
   "Diagnostics" should {
     "print distribution" in {
       val hosts = 1 until 500 map { "10.1.1." + _ + ":11211:4" }

--- a/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/HashableTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.hashing
 
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class HashableTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class HashableTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 
   private[this] val algorithms = Seq(
     Hashable.CRC32_ITU,

--- a/util-hashing/src/test/scala/com/twitter/hashing/KeyHasherTest.scala
+++ b/util-hashing/src/test/scala/com/twitter/hashing/KeyHasherTest.scala
@@ -2,11 +2,11 @@ package com.twitter.hashing
 
 import com.twitter.io.TempFile
 import java.util.Base64
-import org.scalatest.WordSpec
 import scala.collection.mutable.ListBuffer
 import java.nio.charset.StandardCharsets.UTF_8
+import org.scalatest.wordspec.AnyWordSpec
 
-class KeyHasherTest extends WordSpec {
+class KeyHasherTest extends AnyWordSpec {
   def readResource(name: String) = {
     var lines = new ListBuffer[String]()
     val src = scala.io.Source.fromFile(TempFile.fromResourcePath(getClass, "/" + name))

--- a/util-jvm/src/test/scala/com/twitter/jvm/ContentionTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/ContentionTest.scala
@@ -2,9 +2,9 @@ package com.twitter.jvm
 
 import com.twitter.util.{Await, Promise}
 import java.util.concurrent.locks.ReentrantLock
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.funsuite.AnyFunSuite
 
 class Philosopher {
   val ready = new Promise[Unit]
@@ -18,7 +18,7 @@ class Philosopher {
   }
 }
 
-class ContentionTest extends FunSuite with Eventually {
+class ContentionTest extends AnyFunSuite with Eventually {
 
   implicit override val patienceConfig =
     PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = scaled(Span(5, Millis)))

--- a/util-jvm/src/test/scala/com/twitter/jvm/CpuProfileTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/CpuProfileTest.scala
@@ -3,9 +3,9 @@ package com.twitter.jvm
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.Time
 import java.io.ByteArrayOutputStream
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class CpuProfileTest extends FunSuite {
+class CpuProfileTest extends AnyFunSuite {
   test("record") {
 
     // record() calls Time.now 3 times initially, and then 3 times on every loop iteration.

--- a/util-jvm/src/test/scala/com/twitter/jvm/EstimatorTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/EstimatorTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.jvm
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class EstimatorTest extends FunSuite {
+class EstimatorTest extends AnyFunSuite {
   test("LoadAverage") {
     // This makes LoadAverage.a = 1/2 for easy testing.
     val interval = -1d / math.log(0.5)

--- a/util-jvm/src/test/scala/com/twitter/jvm/JvmTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/JvmTest.scala
@@ -5,11 +5,11 @@ import com.twitter.util.Time
 import java.util.logging.{Level, Logger}
 import org.mockito.Matchers.contains
 import org.mockito.Mockito.{times, verify, when}
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.mutable
+import org.scalatest.wordspec.AnyWordSpec
 
-class JvmTest extends WordSpec with MockitoSugar {
+class JvmTest extends AnyWordSpec with MockitoSugar {
   "Jvm" should {
     class JvmHelper(suppliedLogger: Option[Logger] = None) extends Jvm {
       protected override def logger: Logger = suppliedLogger match {

--- a/util-jvm/src/test/scala/com/twitter/jvm/NumProcsTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/NumProcsTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.jvm
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class NumProcsTest extends FunSuite {
+class NumProcsTest extends AnyFunSuite {
 
   test("return the number of available processors according to the runtime by default") {
     assert(System.getProperty("com.twitter.jvm.numProcs") == null)

--- a/util-jvm/src/test/scala/com/twitter/jvm/OptTest.scala
+++ b/util-jvm/src/test/scala/com/twitter/jvm/OptTest.scala
@@ -3,9 +3,9 @@ package com.twitter.jvm
 import java.lang.{Boolean => JBool}
 import java.lang.management.ManagementFactory
 import javax.management.ObjectName
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class OptTest extends FunSuite {
+class OptTest extends AnyFunSuite {
   test("Opts") {
     if (System.getProperty("java.vm.name").contains("HotSpot")) {
       val DiagnosticName =

--- a/util-lint/src/test/scala/com/twitter/util/lint/GlobalRulesTest.scala
+++ b/util-lint/src/test/scala/com/twitter/util/lint/GlobalRulesTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util.lint
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class GlobalRulesTest extends FunSuite {
+class GlobalRulesTest extends AnyFunSuite {
   private val neverRule = Rule.apply(Category.Performance, "R2", "Good") {
     Nil
   }

--- a/util-lint/src/test/scala/com/twitter/util/lint/RuleTest.scala
+++ b/util-lint/src/test/scala/com/twitter/util/lint/RuleTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util.lint
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RuleTest extends FunSuite {
+class RuleTest extends AnyFunSuite {
 
   private def withName(name: String): Rule =
     Rule(Category.Performance, name, "descriptive description") { Nil }

--- a/util-lint/src/test/scala/com/twitter/util/lint/RulesTest.scala
+++ b/util-lint/src/test/scala/com/twitter/util/lint/RulesTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util.lint
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RulesTest extends FunSuite {
+class RulesTest extends AnyFunSuite {
 
   private var flag = false
 

--- a/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FileHandlerTest.scala
@@ -18,7 +18,6 @@ package com.twitter.logging
 
 import java.io._
 import java.util.{Calendar, Date, UUID, logging => javalog}
-import org.scalatest.WordSpec
 import com.twitter.conversions.StorageUnitOps._
 import com.twitter.conversions.DurationOps._
 import com.twitter.io.TempFolder
@@ -26,8 +25,9 @@ import com.twitter.util.Time
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{Files, Path, Paths}
 import java.util.function.BiPredicate
+import org.scalatest.wordspec.AnyWordSpec
 
-class FileHandlerTest extends WordSpec with TempFolder {
+class FileHandlerTest extends AnyWordSpec with TempFolder {
   def reader(filename: String): BufferedReader = {
     new BufferedReader(new InputStreamReader(new FileInputStream(new File(folderName, filename))))
   }

--- a/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/FormatterTest.scala
@@ -18,11 +18,11 @@ package com.twitter.logging
 
 import java.util.{logging => javalog}
 
-import org.scalatest.WordSpec
 
 import com.twitter.conversions.StringOps._
+import org.scalatest.wordspec.AnyWordSpec
 
-class FormatterTest extends WordSpec {
+class FormatterTest extends AnyWordSpec {
   val basicFormatter = new Formatter
 
   val utcFormatter = new Formatter(

--- a/util-logging/src/test/scala/com/twitter/logging/HasLogLevelTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/HasLogLevelTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.logging
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class HasLogLevelTest extends FunSuite {
+class HasLogLevelTest extends AnyFunSuite {
 
   private class WithLogLevel(val logLevel: Level, cause: Throwable = null)
       extends Exception(cause)

--- a/util-logging/src/test/scala/com/twitter/logging/LogRecordTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LogRecordTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.logging
 
 import java.util.logging.{LogRecord => JRecord}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class LogRecordTest extends FunSuite {
+class LogRecordTest extends AnyFunSuite {
   test("LogRecord should getMethod properly") {
     Logger.withLoggers(Nil) {
       new LogRecordTestHelper({ r: JRecord => r.getSourceMethodName() }) {

--- a/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/LoggerTest.scala
@@ -21,10 +21,11 @@ import com.twitter.io.TempFolder
 import java.net.InetSocketAddress
 import java.util.concurrent.{Callable, CountDownLatch, Executors, Future, TimeUnit}
 import java.util.{logging => javalog}
-import org.scalatest.{BeforeAndAfter, WordSpec}
+import org.scalatest.BeforeAndAfter
 import scala.collection.mutable
+import org.scalatest.wordspec.AnyWordSpec
 
-class LoggerTest extends WordSpec with TempFolder with BeforeAndAfter {
+class LoggerTest extends AnyWordSpec with TempFolder with BeforeAndAfter {
   val logLevel =
     Logger.levelNames(Option[String](System.getenv("log")).getOrElse("FATAL").toUpperCase)
 

--- a/util-logging/src/test/scala/com/twitter/logging/PolicyTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/PolicyTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.logging
 
-import org.scalatest.FunSuite
 
 import com.twitter.util.StorageUnit
+import org.scalatest.funsuite.AnyFunSuite
 
-class PolicyTest extends FunSuite {
+class PolicyTest extends AnyFunSuite {
   import Policy._
 
   test("Policy.parse: never") {

--- a/util-logging/src/test/scala/com/twitter/logging/QueueingHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/QueueingHandlerTest.scala
@@ -18,10 +18,10 @@ package com.twitter.logging
 
 import com.twitter.util.Local
 import java.util.{logging => javalog}
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.{IntegrationPatience, Eventually}
+import org.scalatest.wordspec.AnyWordSpec
 
-class QueueingHandlerTest extends WordSpec with Eventually with IntegrationPatience {
+class QueueingHandlerTest extends AnyWordSpec with Eventually with IntegrationPatience {
 
   class MockHandler extends Handler(BareFormatter, None) {
     def publish(record: javalog.LogRecord) = ()

--- a/util-logging/src/test/scala/com/twitter/logging/SyslogHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/SyslogHandlerTest.scala
@@ -19,9 +19,9 @@ package com.twitter.logging
 import java.net.{DatagramPacket, DatagramSocket}
 import java.util.{logging => javalog}
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class SyslogHandlerTest extends WordSpec {
+class SyslogHandlerTest extends AnyWordSpec {
   val record1 = new javalog.LogRecord(Level.FATAL, "fatal message!")
   record1.setLoggerName("net.lag.whiskey.Train")
   record1.setMillis(1206769996722L)

--- a/util-logging/src/test/scala/com/twitter/logging/ThrottledHandlerTest.scala
+++ b/util-logging/src/test/scala/com/twitter/logging/ThrottledHandlerTest.scala
@@ -19,9 +19,10 @@ package com.twitter.logging
 import com.twitter.conversions.DurationOps._
 import com.twitter.io.TempFolder
 import com.twitter.util.Time
-import org.scalatest.{BeforeAndAfter, WordSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.wordspec.AnyWordSpec
 
-class ThrottledHandlerTest extends WordSpec with BeforeAndAfter with TempFolder {
+class ThrottledHandlerTest extends AnyWordSpec with BeforeAndAfter with TempFolder {
   private var handler: StringHandler = _
 
   "ThrottledHandler" should {

--- a/util-reflect/src/test/scala/com/twitter/util/reflect/ProxyTest.scala
+++ b/util-reflect/src/test/scala/com/twitter/util/reflect/ProxyTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.util.reflect
 
 import com.twitter.util.{Future, Promise, Stopwatch}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 object ProxySpec {
   trait TestInterface {
@@ -32,7 +32,7 @@ object ProxySpec {
   }
 }
 
-class ProxyTest extends WordSpec {
+class ProxyTest extends AnyWordSpec {
 
   import ProxySpec._
 

--- a/util-registry/src/test/scala/com/twitter/util/registry/FormatterTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/FormatterTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util.registry
 
-import org.scalatest.FunSuite
 import scala.util.control.NoStackTrace
+import org.scalatest.funsuite.AnyFunSuite
 
-class FormatterTest extends FunSuite {
+class FormatterTest extends AnyFunSuite {
   test("asMap generates reasonable Maps") {
     val registry = new SimpleRegistry
     registry.put(Seq("foo", "bar"), "baz")

--- a/util-registry/src/test/scala/com/twitter/util/registry/LibraryTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/LibraryTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util.registry
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class LibraryTest extends FunSuite {
+class LibraryTest extends AnyFunSuite {
   test("Library.register registers libraries") {
     val simple = new SimpleRegistry
     GlobalRegistry.withRegistry(simple) {

--- a/util-registry/src/test/scala/com/twitter/util/registry/RegistryTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/RegistryTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util.registry
 
 import java.lang.{Character => JCharacter}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-abstract class RegistryTest extends FunSuite {
+abstract class RegistryTest extends AnyFunSuite {
   def mkRegistry(): Registry
   def name: String
 

--- a/util-registry/src/test/scala/com/twitter/util/registry/RosterTest.scala
+++ b/util-registry/src/test/scala/com/twitter/util/registry/RosterTest.scala
@@ -3,10 +3,10 @@ package com.twitter.util.registry
 import java.util.logging.Logger
 import org.mockito.Mockito.{never, verify}
 import org.mockito.Matchers.anyObject
-import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
-class RosterTest extends FunSuite with MockitoSugar {
+class RosterTest extends AnyFunSuite with MockitoSugar {
   def withRoster(fn: (Roster, Logger) => Unit): Unit = {
     val simple = new SimpleRegistry
     simple.put(Seq("foo", "bar"), "fantastic")

--- a/util-routing/src/test/scala/com/twitter/util/routing/PolymorphicRouterCompilationTest.scala
+++ b/util-routing/src/test/scala/com/twitter/util/routing/PolymorphicRouterCompilationTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.util.routing
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 private object PolymorphicRouterCompilationTest {
 
@@ -80,7 +80,7 @@ private object PolymorphicRouterCompilationTest {
 }
 
 // these tests ensure that we properly support polymorphic Router and RouterBuilder types
-class PolymorphicRouterCompilationTest extends FunSuite {
+class PolymorphicRouterCompilationTest extends AnyFunSuite {
   import PolymorphicRouterCompilationTest._
 
   test("Supports routing with polymorphic destinations") {

--- a/util-routing/src/test/scala/com/twitter/util/routing/RouterBuilderTest.scala
+++ b/util-routing/src/test/scala/com/twitter/util/routing/RouterBuilderTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util.routing
 
 import com.twitter.util.routing.simple.{SimpleRoute, SimpleRouter}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RouterBuilderTest extends FunSuite {
+class RouterBuilderTest extends AnyFunSuite {
 
   private object TestRouter {
     def newBuilder(): RouterBuilder[String, SimpleRoute, SimpleRouter] =

--- a/util-routing/src/test/scala/com/twitter/util/routing/RouterTest.scala
+++ b/util-routing/src/test/scala/com/twitter/util/routing/RouterTest.scala
@@ -5,9 +5,9 @@ import com.twitter.util.routing.dynamic.{DynamicRouter, DynamicRoute, Method, Re
 import com.twitter.util.routing.simple.{SimpleRoute, SimpleRouter}
 import com.twitter.util.{Await, Awaitable, Closable, Future, Time}
 import java.util.concurrent.atomic.AtomicBoolean
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RouterTest extends FunSuite {
+class RouterTest extends AnyFunSuite {
 
   private def await[T](awaitable: Awaitable[T]): T =
     Await.result(awaitable, 2.seconds)

--- a/util-security/src/test/scala/com/twitter/util/security/CredentialsTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/CredentialsTest.scala
@@ -16,10 +16,10 @@
 
 package com.twitter.util.security
 
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.Checkers
+import org.scalatest.funsuite.AnyFunSuite
 
-class CredentialsTest extends FunSuite with Checkers {
+class CredentialsTest extends AnyFunSuite with Checkers {
   test("parse a simple auth file") {
     val content = "username: root\npassword: hellokitty\n"
     val result = Credentials(content)

--- a/util-security/src/test/scala/com/twitter/util/security/NullPrincipalTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/NullPrincipalTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util.security
 
 import java.security.Principal
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class NullPrincipalTest extends FunSuite {
+class NullPrincipalTest extends AnyFunSuite {
 
   test("NullPrincipal is a Principal") {
     val principal: Principal = NullPrincipal

--- a/util-security/src/test/scala/com/twitter/util/security/NullSslSessionContextTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/NullSslSessionContextTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util.security
 
 import javax.net.ssl.SSLSessionContext
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class NullSslSessionContextTest extends FunSuite {
+class NullSslSessionContextTest extends AnyFunSuite {
 
   test("NullSslSessionContext is an SSLSessionContext") {
     val sslSessionContext: SSLSessionContext = NullSslSessionContext

--- a/util-security/src/test/scala/com/twitter/util/security/NullSslSessionTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/NullSslSessionTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util.security
 
 import javax.net.ssl.SSLSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class NullSslSessionTest extends FunSuite {
+class NullSslSessionTest extends AnyFunSuite {
 
   test("NullSslSession is an SSLSession") {
     val sslSession: SSLSession = NullSslSession

--- a/util-security/src/test/scala/com/twitter/util/security/PemFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/PemFileTest.scala
@@ -3,9 +3,9 @@ package com.twitter.util.security
 import com.twitter.io.TempFile
 import com.twitter.util.Try
 import java.io.File
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PemFileTest extends FunSuite {
+class PemFileTest extends AnyFunSuite {
 
   private[this] def readPemFileMessage(messageType: String)(tempFile: File): Try[String] = {
     val pemFile = new PemFile(tempFile)

--- a/util-security/src/test/scala/com/twitter/util/security/Pkcs8EncodedKeySpecFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/Pkcs8EncodedKeySpecFileTest.scala
@@ -4,9 +4,9 @@ import com.twitter.io.TempFile
 import com.twitter.util.Try
 import java.io.File
 import java.security.spec.PKCS8EncodedKeySpec
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class Pkcs8EncodedKeySpecFileTest extends FunSuite {
+class Pkcs8EncodedKeySpecFileTest extends AnyFunSuite {
 
   private[this] val readKeySpecFromFile: File => Try[PKCS8EncodedKeySpec] =
     (tempFile) => {

--- a/util-security/src/test/scala/com/twitter/util/security/Pkcs8KeyManagerFactoryTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/Pkcs8KeyManagerFactoryTest.scala
@@ -3,9 +3,9 @@ package com.twitter.util.security
 import com.twitter.io.TempFile
 import java.io.File
 import javax.net.ssl.{KeyManager, X509KeyManager}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PKCS8KeyManagerFactoryTest extends FunSuite {
+class PKCS8KeyManagerFactoryTest extends AnyFunSuite {
 
   private[this] def assertContainsCertsAndKey(keyManager: KeyManager, numCerts: Int = 1): Unit = {
     assert(keyManager.isInstanceOf[X509KeyManager])

--- a/util-security/src/test/scala/com/twitter/util/security/PrivateKeyFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/PrivateKeyFileTest.scala
@@ -2,9 +2,9 @@ package com.twitter.util.security
 
 import com.twitter.io.TempFile
 import java.security.spec.InvalidKeySpecException
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PrivateKeyFileTest extends FunSuite {
+class PrivateKeyFileTest extends AnyFunSuite {
 
   test("File is garbage") {
     // Lines were manually deleted from a real pkcs 8 pem file

--- a/util-security/src/test/scala/com/twitter/util/security/X500PrincipalInfoTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/X500PrincipalInfoTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.util.security
 
 import javax.security.auth.x500.X500Principal
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class X500PrincipalInfoTest extends FunSuite {
+class X500PrincipalInfoTest extends AnyFunSuite {
 
   test("Empty principal") {
     val principal = new X500Principal("")

--- a/util-security/src/test/scala/com/twitter/util/security/X509CertificateFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/X509CertificateFileTest.scala
@@ -4,9 +4,9 @@ import com.twitter.io.TempFile
 import com.twitter.util.Try
 import java.io.File
 import java.security.cert.{CertificateException, X509Certificate}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class X509CertificateFileTest extends FunSuite {
+class X509CertificateFileTest extends AnyFunSuite {
 
   private[this] def assertIsCslCert(cert: X509Certificate): Unit = {
     val subjectData: String = cert.getSubjectX500Principal.getName()

--- a/util-security/src/test/scala/com/twitter/util/security/X509CrlFileTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/X509CrlFileTest.scala
@@ -4,9 +4,9 @@ import com.twitter.io.TempFile
 import com.twitter.util.Try
 import java.io.File
 import java.security.cert.{CRLException, X509CRL}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class X509CrlFileTest extends FunSuite {
+class X509CrlFileTest extends AnyFunSuite {
 
   private[this] def assertCrlException(tryCrl: Try[X509CRL]): Unit =
     PemFileTestUtils.assertException[CRLException, X509CRL](tryCrl)

--- a/util-security/src/test/scala/com/twitter/util/security/X509TrustManagerFactoryTest.scala
+++ b/util-security/src/test/scala/com/twitter/util/security/X509TrustManagerFactoryTest.scala
@@ -4,9 +4,9 @@ import com.twitter.io.TempFile
 import java.io.File
 import java.security.cert.X509Certificate
 import javax.net.ssl.{TrustManager, X509TrustManager}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class X509TrustManagerFactoryTest extends FunSuite {
+class X509TrustManagerFactoryTest extends AnyFunSuite {
 
   private[this] def loadCertFromResource(resourcePath: String): X509Certificate = {
     val tempFile = TempFile.fromResourcePath(resourcePath)

--- a/util-slf4j-api/src/test/scala/com/twitter/util/logging/LoggingTest.scala
+++ b/util-slf4j-api/src/test/scala/com/twitter/util/logging/LoggingTest.scala
@@ -3,11 +3,12 @@ package com.twitter.util.logging
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSuite, Matchers}
 import org.slf4j
 import scala.language.reflectiveCalls
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class LoggingTest extends FunSuite with Matchers with MockitoSugar {
+class LoggingTest extends AnyFunSuite with Matchers with MockitoSugar {
 
   /* Trace */
 

--- a/util-slf4j-api/src/test/scala/com/twitter/util/logging/MarkerLoggingTest.scala
+++ b/util-slf4j-api/src/test/scala/com/twitter/util/logging/MarkerLoggingTest.scala
@@ -3,12 +3,13 @@ package com.twitter.util.logging
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSuite, Matchers}
 import org.slf4j
 import org.slf4j.Marker
 import scala.language.reflectiveCalls
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class MarkerLoggingTest extends FunSuite with Matchers with MockitoSugar {
+class MarkerLoggingTest extends AnyFunSuite with Matchers with MockitoSugar {
 
   test("Marker Logging#trace enabled") {
     val f = fixture(_.isTraceEnabled(anyObject[Marker]), isEnabled = true)

--- a/util-slf4j-api/src/test/scala/com/twitter/util/logging/SerializableLoggingTest.scala
+++ b/util-slf4j-api/src/test/scala/com/twitter/util/logging/SerializableLoggingTest.scala
@@ -2,9 +2,9 @@ package com.twitter.util.logging
 
 import com.twitter.io.TempFolder
 import java.io._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SerializableLoggingTest extends FunSuite with TempFolder {
+class SerializableLoggingTest extends AnyFunSuite with TempFolder {
 
   def read[T](filename: String): T = {
     new ObjectInputStream(new FileInputStream(new File(folderName, filename)))

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/BroadcastStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/BroadcastStatsReceiverTest.scala
@@ -2,9 +2,10 @@ package com.twitter.finagle.stats
 
 import com.twitter.util.{Future, Await}
 
-import org.scalatest.{Matchers, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class BroadcastStatsReceiverTest extends FunSuite with Matchers {
+class BroadcastStatsReceiverTest extends AnyFunSuite with Matchers {
 
   test("counter") {
     val recv1 = new InMemoryStatsReceiver

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/CachedRegexTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/CachedRegexTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.finagle.stats
 
-import org.scalatest.FunSuite
 import scala.jdk.CollectionConverters._
+import org.scalatest.funsuite.AnyFunSuite
 
-class CachedRegexTest extends FunSuite {
+class CachedRegexTest extends AnyFunSuite {
   test("Lets through things it should let through") {
     val cachedRegex = new CachedRegex("foo".r)
     val original: Map[String, Number] = Map("bar" -> 3)

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/CategorizingExceptionStatsHandlerTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/CategorizingExceptionStatsHandlerTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.finagle.stats
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class CategorizingExceptionStatsHandlerTest extends FunSuite {
+class CategorizingExceptionStatsHandlerTest extends AnyFunSuite {
   val categorizer = (t: Throwable) => { "clienterrors" }
 
   test("uses category, source, exception chains and rollup") {

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/CumulativeGaugeTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/CumulativeGaugeTest.scala
@@ -2,10 +2,10 @@ package com.twitter.finagle.stats
 
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.funsuite.AnyFunSuite
 
-class CumulativeGaugeTest extends FunSuite with Eventually with IntegrationPatience {
+class CumulativeGaugeTest extends AnyFunSuite with Eventually with IntegrationPatience {
 
   private[this] val sameThreadExecutor = new Executor {
     def execute(command: Runnable): Unit = command.run()

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/DelegatingStatsReceiverTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.finagle.stats
 
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.funsuite.AnyFunSuite
 
-class DelegatingStatsReceiverTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
+class DelegatingStatsReceiverTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 
   class Ctx {
     var leafCounter = 0

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/DenylistStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/DenylistStatsReceiverTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.finagle.stats
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class DenylistStatsReceiverTest extends FunSuite {
+class DenylistStatsReceiverTest extends AnyFunSuite {
   // scalafix:off StoreGaugesAsMemberVariables
   test("DenylistStatsReceiver denylists properly") {
     val inmemory = new InMemoryStatsReceiver()

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/InMemoryStatsReceiverTest.scala
@@ -2,11 +2,11 @@ package com.twitter.finagle.stats
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import scala.collection.parallel.immutable.ParRange
+import org.scalatest.funsuite.AnyFunSuite
 
-class InMemoryStatsReceiverTest extends FunSuite with Eventually with IntegrationPatience {
+class InMemoryStatsReceiverTest extends AnyFunSuite with Eventually with IntegrationPatience {
 
   // scalafix:off StoreGaugesAsMemberVariables
   test("clear") {

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/LazyStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/LazyStatsReceiverTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.finagle.stats
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class LazyStatsReceiverTest extends FunSuite {
+class LazyStatsReceiverTest extends AnyFunSuite {
   test("Doesn't eagerly initialize counters") {
     val underlying = new InMemoryStatsReceiver()
     val wrapped = new LazyStatsReceiver(underlying)

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/MultiCategorizingExceptionStatsHandlerTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/MultiCategorizingExceptionStatsHandlerTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.finagle.stats
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class MultiCategorizingExceptionStatsHandlerTest extends FunSuite {
+class MultiCategorizingExceptionStatsHandlerTest extends AnyFunSuite {
   test("uses label, flags, source, exception chain and rolls up") {
     val receiver = new InMemoryStatsReceiver
 

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/StatsReceiverTest.scala
@@ -4,10 +4,10 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future}
 import java.util.concurrent.TimeUnit
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
 import scala.collection.mutable.ArrayBuffer
+import org.scalatest.funsuite.AnyFunSuite
 
-class StatsReceiverTest extends FunSuite {
+class StatsReceiverTest extends AnyFunSuite {
   test("RollupStatsReceiver counter/stats") {
     val mem = new InMemoryStatsReceiver
     val receiver = new RollupStatsReceiver(mem)

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/VerbosityAdjustingStatsReceiverTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/VerbosityAdjustingStatsReceiverTest.scala
@@ -1,8 +1,9 @@
 package com.twitter.finagle.stats
 
-import org.scalatest.{FunSuite, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funsuite.AnyFunSuite
 
-class VerbosityAdjustingStatsReceiverTest extends FunSuite with OneInstancePerTest {
+class VerbosityAdjustingStatsReceiverTest extends AnyFunSuite with OneInstancePerTest {
 
   val inMemory = new InMemoryStatsReceiver()
   val verbose = new VerbosityAdjustingStatsReceiver(inMemory, Verbosity.Debug)

--- a/util-stats/src/test/scala/com/twitter/finagle/stats/WithHistogramDetailsTest.scala
+++ b/util-stats/src/test/scala/com/twitter/finagle/stats/WithHistogramDetailsTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.finagle.stats
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class WithHistogramDetailsTest extends FunSuite {
+class WithHistogramDetailsTest extends AnyFunSuite {
   test("AggregateWithHistogramDetails rejects empties") {
     intercept[IllegalArgumentException] {
       AggregateWithHistogramDetails(Nil)

--- a/util-test/src/main/scala/com/twitter/logging/TestLogging.scala
+++ b/util-test/src/main/scala/com/twitter/logging/TestLogging.scala
@@ -18,13 +18,14 @@ package com.twitter.logging
 
 import java.util.{logging => jlogging}
 
-import org.scalatest.{BeforeAndAfter, WordSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * Specify logging during unit tests via system property, defaulting to FATAL only.
  */
 @deprecated("Prefer using slf4j for logging", "2019-11-20")
-trait TestLogging extends BeforeAndAfter { self: WordSpec =>
+trait TestLogging extends BeforeAndAfter { self: AnyWordSpec =>
   val logLevel: Level =
     Logger.levelNames(Option[String](System.getenv("log")).getOrElse("FATAL").toUpperCase)
 

--- a/util-test/src/test/scala/com/twitter/util/testing/ArgumentCaptureTest.scala
+++ b/util-test/src/test/scala/com/twitter/util/testing/ArgumentCaptureTest.scala
@@ -2,10 +2,10 @@ package com.twitter.util.testing
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
 
-class ArgumentCaptureTest extends FunSuite with MockitoSugar with ArgumentCapture {
+class ArgumentCaptureTest extends AnyFunSuite with MockitoSugar with ArgumentCapture {
   class MockSubject {
     def method1(arg: String): Long = 0L
     def method2(arg1: String, arg2: String): Long = 0L

--- a/util-thrift/src/test/scala/com/twitter/util/ThriftCodecTest.scala
+++ b/util-thrift/src/test/scala/com/twitter/util/ThriftCodecTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ThriftCodecTest extends FunSuite {
+class ThriftCodecTest extends AnyFunSuite {
 
   private def roundTrip(codec: ThriftCodec[TestThriftStructure, _]): Unit = {
     val struct = new TestThriftStructure("aString", 5)

--- a/util-thrift/src/test/scala/com/twitter/util/ThriftSerializerTest.scala
+++ b/util-thrift/src/test/scala/com/twitter/util/ThriftSerializerTest.scala
@@ -16,9 +16,9 @@
 
 package com.twitter.util
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ThriftSerializerTest extends WordSpec {
+class ThriftSerializerTest extends AnyWordSpec {
   val aString = "me gustan los tacos y los burritos"
   val aNumber = 42
   val original = new TestThriftStructure(aString, aNumber)

--- a/util-tunable/src/test/scala/com/twitter/util/tunable/JsonTunableMapperTest.scala
+++ b/util-tunable/src/test/scala/com/twitter/util/tunable/JsonTunableMapperTest.scala
@@ -6,13 +6,13 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.twitter.conversions.StorageUnitOps._
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Duration, Return, StorageUnit, Throw}
-import org.scalatest.FunSuite
 import scala.jdk.CollectionConverters._
+import org.scalatest.funsuite.AnyFunSuite
 
 // Used for veryifying custom deserialization
 case class Foo(number: Double)
 
-class JsonTunableMapperTest extends FunSuite {
+class JsonTunableMapperTest extends AnyFunSuite {
 
   test("returns a Throw if json is empty") {
     JsonTunableMapper().parse("") match {

--- a/util-tunable/src/test/scala/com/twitter/util/tunable/ServiceLoadedTunableMapTest.scala
+++ b/util-tunable/src/test/scala/com/twitter/util/tunable/ServiceLoadedTunableMapTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.util.tunable
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 class ServiceLoadedTunableTestClient1 extends ServiceLoadedTunableMap with TunableMap.Proxy {
 
@@ -23,7 +23,7 @@ class ServiceLoadedTunableTestClient2Dup extends ServiceLoadedTunableMap with Tu
   def id: String = "client2"
 }
 
-class ServiceLoadedTunableMapTest extends FunSuite {
+class ServiceLoadedTunableMapTest extends AnyFunSuite {
 
   test(
     "IllegalArgumentException thrown when there is more than one ServiceLoadedTunableMap " +

--- a/util-tunable/src/test/scala/com/twitter/util/tunable/TunableMapTest.scala
+++ b/util-tunable/src/test/scala/com/twitter/util/tunable/TunableMapTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util.tunable
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class MutableTest extends FunSuite {
+class MutableTest extends AnyFunSuite {
 
   test("map is initially empty") {
     assert(TunableMap.newMutable().entries.size == 0)
@@ -384,7 +384,7 @@ class MutableTest extends FunSuite {
   }
 }
 
-class NullTunableMapTest extends FunSuite {
+class NullTunableMapTest extends AnyFunSuite {
 
   test("NullTunableMap returns Tunable.None") {
     val nullTunableMap = NullTunableMap

--- a/util-tunable/src/test/scala/com/twitter/util/tunable/TunableTest.scala
+++ b/util-tunable/src/test/scala/com/twitter/util/tunable/TunableTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.util.tunable
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TunableTest extends FunSuite {
+class TunableTest extends AnyFunSuite {
 
   test("Tunable cannot have empty id") {
     intercept[IllegalArgumentException] {

--- a/util-zk-test/src/test/scala/com/twitter/zk/ServerCnxnFactoryTest.scala
+++ b/util-zk-test/src/test/scala/com/twitter/zk/ServerCnxnFactoryTest.scala
@@ -4,9 +4,10 @@ import com.twitter.io.TempDirectory
 import java.io.File
 import java.net.InetAddress
 import org.apache.zookeeper.server.ZooKeeperServer
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
-class ServerCnxnFactoryTest extends FunSuite with BeforeAndAfter {
+class ServerCnxnFactoryTest extends AnyFunSuite with BeforeAndAfter {
   val addr = InetAddress.getLocalHost
 
   var testServer: ZooKeeperServer = null

--- a/util-zk/src/test/scala/com/twitter/zk/ConnectorTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ConnectorTest.scala
@@ -1,12 +1,12 @@
 package com.twitter.zk
 
 import org.mockito.Mockito._
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 
 import com.twitter.util.Future
+import org.scalatest.wordspec.AnyWordSpec
 
-class ConnectorTest extends WordSpec with MockitoSugar {
+class ConnectorTest extends AnyWordSpec with MockitoSugar {
   "Connector.RoundRobin" should {
     "require underlying connections" in {
       intercept[Exception] {

--- a/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZNodeTest.scala
@@ -3,10 +3,10 @@ package com.twitter.zk
 /**
  * @author ver@twitter.com
  */
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.wordspec.AnyWordSpec
 
-class ZNodeTest extends WordSpec with MockitoSugar {
+class ZNodeTest extends AnyWordSpec with MockitoSugar {
   "ZNode" should {
     class ZNodeSpecHelper {
       val zk = mock[ZkClient]

--- a/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/ZkClientTest.scala
@@ -10,14 +10,14 @@ import org.mockito.Mockito._
 import org.mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.logging.{Level, Logger}
 import com.twitter.util._
+import org.scalatest.wordspec.AnyWordSpec
 
-class ZkClientTest extends WordSpec with MockitoSugar {
+class ZkClientTest extends AnyWordSpec with MockitoSugar {
   Logger.get("").setLevel(Level.FATAL)
 
   implicit val javaTimer = new JavaTimer(true)

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ShardCoordinatorTest.scala
@@ -3,14 +3,14 @@ package com.twitter.zk.coordination
 import scala.jdk.CollectionConverters._
 
 import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
-import org.scalatest.WordSpec
 import org.scalatestplus.mockito.MockitoSugar
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, JavaTimer}
 import com.twitter.zk.{NativeConnector, RetryPolicy, ZkClient}
+import org.scalatest.wordspec.AnyWordSpec
 
-class ShardCoordinatorTest extends WordSpec with MockitoSugar {
+class ShardCoordinatorTest extends AnyWordSpec with MockitoSugar {
 
   "ShardCoordinator" should {
 

--- a/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
+++ b/util-zk/src/test/scala/com/twitter/zk/coordination/ZkAsyncSemaphoreTest.scala
@@ -7,14 +7,14 @@ import com.twitter.zk.{NativeConnector, RetryPolicy, ZkClient, ZNode}
 import java.util.concurrent.ConcurrentLinkedQueue
 import org.apache.zookeeper.KeeperException.NoNodeException
 import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.Waiters
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
 import scala.jdk.CollectionConverters._
+import org.scalatest.wordspec.AnyWordSpec
 
-class ZkAsyncSemaphoreTest extends WordSpec with MockitoSugar with Waiters {
+class ZkAsyncSemaphoreTest extends AnyWordSpec with MockitoSugar with Waiters {
 
   "ZkAsyncSemaphore" should {
 


### PR DESCRIPTION
Problem

Use of many deprecated names since upgrading to scalatest 3.1

Solution

Run using autofix from https://github.com/scalatest/autofix/tree/master/3.1.x

Result

All deprecated names replaced with their new names