### PR TITLE
Upgrade to scala-parser-combinators 2.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -408,6 +408,7 @@ lazy val utilCore = Project(
     libraryDependencies ++= Seq(
       caffeineLib % "test",
       scalacheckLib,
+      "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1",
       "org.mockito" % "mockito-core" % mockitoVersion % "test",
     ) ++ {
       if (scalaVersion.value.startsWith("2")) {


### PR DESCRIPTION
## Problem

Use scala-parser-combinator ~2.0.0~ 2.1.1, which is compatible for Scala 2.11 - Scala 3.0.0.

If a project using twitter-util has a dependency to scala-parser-combinator 2.0.0 with sbt 1.5.x, an error like this will be shown:
```
[info] [error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[info] [error]
[info] [error] 	* org.scala-lang.modules:scala-parser-combinators_2.12:2.0.0 (early-semver) is selected over 1.1.2
[info] [error] 	    +- org.wvlet.airframe:airframe-launcher_2.12:21.4.1-38-0bf13a68-20210513-1748-SNAPSHOT (depends on 2.0.0)
[info] [error] 	    +- org.wvlet.airframe:airframe-control_2.12:21.4.1-38-0bf13a68-20210513-1748-SNAPSHOT (depends on 2.0.0)
[info] [error] 	    +- com.twitter:util-core_2.12:21.4.0                  (depends on 1.1.2)
```
Related article: https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html

## Solution

Upgrade the scala-parser-combinator version of twitter/util or adding this setting to build.sbt:
```scala
ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parser-combinators" % "always"
```

## Result

There should be no behavior change with this upgrade. 

