### PR TITLE
Update Scala 2.13.1 to 2.13.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,8 +78,8 @@ def jdk11GcJavaOptions: Seq[String] = {
 }
 
 val defaultProjectSettings = Seq(
-  scalaVersion := "2.12.12",
-  crossScalaVersions := Seq("2.12.12", "2.13.1")
+  scalaVersion := "2.13.6",
+  crossScalaVersions := Seq("2.12.12", "2.13.6")
 )
 
 val baseSettings = Seq(

--- a/util-validator/src/main/scala/com/twitter/util/validation/ScalaValidator.scala
+++ b/util-validator/src/main/scala/com/twitter/util/validation/ScalaValidator.scala
@@ -860,12 +860,12 @@ class ScalaValidator private[validation] (
     val results = new mutable.ListBuffer[ConstraintViolation[T]]()
     val parameters: Array[Parameter] = executableDescriptor.executable.getParameters
     val parameterNamesList: Array[String] =
-      parameterNames match {
+      (parameterNames match {
         case Some(names) =>
           names
         case _ =>
           getExecutableParameterNames(executableDescriptor.executable)
-      }
+      }).map(DescriptorFactory.unmangleName) // parameter names are encoded since Scala 2.13.5
 
     // executable parameter constraints
     var index = 0


### PR DESCRIPTION
Problem

The latest Scala 2.13.x version is compatible with Scala 3.0.0 and includes many useful compiler-tools (e.g. warnings) to make the transition - and development in general - easier. Even if we don't have a real Scala 3 cross-build, 2.13.6 can be consumed by Scala 3 projects.

Solution

Updating Scala 2.13.1 to 2.13.6

Result

The build uses Scala 2.13.6. I also used the 2.13.x version as default as it has many extremely useful warnings that 2.12.x doesn't have. The only part that needed fixing is some reflection code as 2.13.5 changed encoding of method-parameter names.

As usual, I cannot tell if this clashes with any Twitter-internal things, so please tell me if it does.