### PR TITLE
Update scalacheck to 1.15.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val zkDependency = "org.apache.zookeeper" % "zookeeper" % zkVersion excludeAll (
 val guavaLib = "com.google.guava" % "guava" % "25.1-jre"
 val caffeineLib = "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5"
 val jsr305Lib = "com.google.code.findbugs" % "jsr305" % "2.0.1"
-val scalacheckLib = "org.scalacheck" %% "scalacheck" % "1.14.3" % "test"
+val scalacheckLib = "org.scalacheck" %% "scalacheck" % "1.15.4" % "test"
 val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion
 
 def travisTestJavaOptions: Seq[String] = {


### PR DESCRIPTION
**Note**: This is split out from the big WIP PR #290 and can be done separately as preparation for Scala 3.

**Problem**

Scala 3 requires Scalacheck 1.15.x but the build currently uses 1.14.x

**Solution**

Upgrading Scalacheck should be fairly simple as I've yet to see any binary compatibility issues between 1.14.x and 1.15.x.
If we can use the newer version across all Scala versions it will simplify Scala 3 cross-building (otherwise we'd have to use different versions which can be finicky).

**Result**

The tests use Scalacheck 1.15.4. 
We still use `scalatestplus scalacheck-1-14` because there is no `1-15` version available for Scalatest 3.1.x but in my experience there are no binary compatibility issues, so it's worth a try. Since this only affects tests the small risk of a crash is acceptable (and problems should be found in CI).

Cheers
~ Felix