### PR TITLE
Match Scala version for 2.13.6 in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.12.12, 2.13.1]
+        scala: [2.12.12, 2.13.6]
         java: ['1.8', '1.11']
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When I opened the PR to update Scala to 2.13.6 I forgot to update the version for Github Actions. This PR fixes that.

As a side-note: Have you considered using [sbt-github-actions](https://github.com/djspiewak/sbt-github-actions)? It's pretty good in keeping these things consistent and many projects use it successfully.

Cheers
~ Felix