### PR TITLE
util/util-core: Fix conversions to units from Int in Scala3

### DIFF
--- a/util-core/src/main/scala/com/twitter/conversions/DurationOps.scala
+++ b/util-core/src/main/scala/com/twitter/conversions/DurationOps.scala
@@ -1,7 +1,9 @@
 package com.twitter.conversions
 
 import com.twitter.util.Duration
+
 import java.util.concurrent.TimeUnit
+import scala.language.implicitConversions
 
 /**
  * Implicits for writing readable [[com.twitter.util.Duration]]s.
@@ -36,5 +38,16 @@ object DurationOps {
     def days: Duration = Duration(numNanos, TimeUnit.DAYS)
     def day: Duration = days
   }
+
+  /**
+   * Forwarder for Int, as Scala 3.0 doesn't seem to do the implicit conversion to Long anymore.
+   * This is not a bug, as Scala 2.13 already had a flag ("-Ywarn-implicit-widening") to turn on warnings/errors
+   * for that.
+   *
+   * The implicit conversion from Int to Long here doesn't lose precision and keeps backwards source compatibliity
+   * with previous releases.
+   */
+  implicit def richDurationFromInt(numNanos: Int): RichDuration =
+    new RichDuration(numNanos.toLong)
 
 }

--- a/util-core/src/main/scala/com/twitter/conversions/StorageUnitOps.scala
+++ b/util-core/src/main/scala/com/twitter/conversions/StorageUnitOps.scala
@@ -2,6 +2,8 @@ package com.twitter.conversions
 
 import com.twitter.util.StorageUnit
 
+import scala.language.implicitConversions
+
 /**
  * Implicits for writing readable [[com.twitter.util.StorageUnit]]s.
  *
@@ -34,4 +36,15 @@ object StorageUnitOps {
     def million: Long = numBytes * 1000 * 1000
     def billion: Long = numBytes * 1000 * 1000 * 1000
   }
+
+  /**
+   * Forwarder for Int, as Scala 3.0 doesn't seem to do the implicit conversion to Long anymore.
+   * This is not a bug, as Scala 2.13 already had a flag ("-Ywarn-implicit-widening") to turn on warnings/errors
+   * for that.
+   *
+   * The implicit conversion from Int to Long here doesn't lose precision and keeps backwards source compatibliity
+   * with previous releases.
+   */
+  implicit def richStorageUnitFromInt(numBytes: Int): RichStorageUnit =
+    new RichStorageUnit(numBytes.toLong)
 }

--- a/util-core/src/main/scala/com/twitter/conversions/U64Ops.scala
+++ b/util-core/src/main/scala/com/twitter/conversions/U64Ops.scala
@@ -1,5 +1,7 @@
 package com.twitter.conversions
 
+import scala.language.implicitConversions
+
 object U64Ops {
 
   /**
@@ -18,5 +20,16 @@ object U64Ops {
   implicit class RichU64Long(val self: Long) extends AnyVal {
     def toU64HexString: String = "%016x".format(self)
   }
+
+  /**
+   * Forwarder for Int, as Scala 3.0 doesn't seem to do the implicit conversion to Long anymore.
+   * This is not a bug, as Scala 2.13 already had a flag ("-Ywarn-implicit-widening") to turn on warnings/errors
+   * for that.
+   *
+   * The implicit conversion from Int to Long here doesn't lose precision and keeps backwards source compatibliity
+   * with previous releases.
+   */
+  implicit def richU64LongFromInt(self: Int): RichU64Long =
+    new RichU64Long(self.toLong)
 
 }

--- a/util-core/src/test/scala/com/twitter/conversions/DurationOpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/DurationOpsTest.scala
@@ -3,8 +3,9 @@ package com.twitter.conversions
 import com.twitter.util.Duration
 import com.twitter.conversions.DurationOps._
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class DurationOpsTest extends AnyFunSuite {
+class DurationOpsTest extends AnyFunSuite with ScalaCheckPropertyChecks {
   test("converts Duration.Zero") {
     assert(0.seconds eq Duration.Zero)
     assert(0.milliseconds eq Duration.Zero)
@@ -15,6 +16,12 @@ class DurationOpsTest extends AnyFunSuite {
     assert(1.seconds == Duration.fromSeconds(1))
     assert(123.milliseconds == Duration.fromMilliseconds(123))
     assert(100L.nanoseconds == Duration.fromNanoseconds(100L))
+  }
+
+  test("conversion works for Int values") {
+    forAll { (intValue: Int) =>
+      assert(intValue.seconds == intValue.toLong.seconds)
+    }
   }
 
 }

--- a/util-core/src/test/scala/com/twitter/conversions/StorageUnitOpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/StorageUnitOpsTest.scala
@@ -3,8 +3,9 @@ package com.twitter.conversions
 import com.twitter.util.StorageUnit
 import com.twitter.conversions.StorageUnitOps._
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class StorageUnitOpsTest extends AnyFunSuite {
+class StorageUnitOpsTest extends AnyFunSuite with ScalaCheckPropertyChecks {
 
   test("converts") {
     assert(StorageUnit.fromBytes(1) == 1.byte)
@@ -24,6 +25,12 @@ class StorageUnitOpsTest extends AnyFunSuite {
 
     assert(StorageUnit.fromPetabytes(1) == 1.petabyte)
     assert(StorageUnit.fromPetabytes(7) == 7.petabytes)
+  }
+
+  test("conversion works for Int values") {
+    forAll { (intValue: Int) =>
+      assert(intValue.bytes == intValue.toLong.bytes)
+    }
   }
 
 }

--- a/util-core/src/test/scala/com/twitter/conversions/U64OpsTest.scala
+++ b/util-core/src/test/scala/com/twitter/conversions/U64OpsTest.scala
@@ -16,4 +16,10 @@ class U64OpsTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
       assert(s.toU64Long == java.lang.Long.parseUnsignedLong(s, 16))
     }
   }
+
+  test("conversion works for Int values") {
+    forAll { (intValue: Int) =>
+      assert(intValue.toU64HexString == intValue.toLong.toU64HexString)
+    }
+  }
 }


### PR DESCRIPTION
This fixes lost source-compatibility for unit conversions from `Int` values in Scala3. As discussed in #295 I extracted/adapted this from #290 ([previous discussion](https://github.com/twitter/util/pull/290/files#r680089697)).

Previously something like `1.toInt.second` did compile in Scala2 (with default settings) but didn't in Scala3.

I added forwarders for all units which use `Long` as base, as that seemed reasonable and safe. I didn't add an implicit conversion from `Float` to `Double` because floating-point types are dumb and I don't trust the conversion to be lossless in all cases.

I'll adapt #295 once this is merged.