### PR TITLE
Update json4s version to 4.0.3 and factor into val

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val releaseVersion = "21.12.0-SNAPSHOT"
 
 val slf4jVersion = "1.7.30"
 val jacksonVersion = "2.11.4"
+val json4sVersion = "4.0.3"
 val mockitoVersion = "3.3.3"
 val mockitoScalaVersion = "1.14.8"
 
@@ -505,7 +506,7 @@ lazy val utilJackson = Project(
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion exclude ("com.google.guava", "guava"),
       "jakarta.validation" % "jakarta.validation-api" % "3.0.0",
-      "org.json4s" %% "json4s-core" % "3.6.11",
+      "org.json4s" %% "json4s-core" % json4sVersion,
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion % "test",
       scalacheckLib,
       "org.scalatestplus" %% "scalacheck-1-14" % "3.1.2.0" % "test",
@@ -725,7 +726,7 @@ lazy val utilValidator = Project(
       "jakarta.validation" % "jakarta.validation-api" % "3.0.0",
       "org.hibernate.validator" % "hibernate-validator" % "7.0.1.Final",
       "org.glassfish" % "jakarta.el" % "4.0.0",
-      "org.json4s" %% "json4s-core" % "3.6.7",
+      "org.json4s" %% "json4s-core" % json4sVersion,
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion % "test",
       "org.scalatestplus" %% "scalacheck-1-14" % "3.1.2.0" % "test",
       "org.slf4j" % "slf4j-simple" % slf4jVersion % "test"


### PR DESCRIPTION
# Problem

The latest version of [json4s](https://github.com/json4s/json4s) is 4.0.3. 

util-jackson depends on json4s 3.6.11, and util-validator depends on json4s 3.6.7. (Seems like an accident that these are different.)

Other popular libraries, such as [jwt-scala](https://github.com/jwt-scala/jwt-scala), now depend on json4s 4.0.3. This creates binary compatibility problems when Twitter Util is used in conjunction with these libraries:

```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.json4s:json4s-core_2.12:4.0.3 (early-semver) is selected over {3.6.11, 3.6.7}
[error] 	    +- com.github.jwt-scala:jwt-json4s-common_2.12:9.0.2  (depends on 4.0.3)
[error] 	    +- com.twitter:util-validator_2.12:21.11.0            (depends on 3.6.7)
[error] 	    +- com.twitter:util-jackson_2.12:21.11.0              (depends on 3.6.11)
[error] 
```

# Solution

Twitter Util should bump to json4s 4.0.3. I know that all libraries in the Twitter Stack bump these dependencies at the same time, so I have also provided a [PR for Finatra](https://github.com/twitter/finatra/pull/572). [bijection](https://github.com/twitter/bijection) is already on json4s 4.0.3. [scrooge](https://github.com/twitter/scrooge) and [finagle](https://github.com/twitter/finagle) do not depend on json4s.

`sbt test` succeeds with json4s 4.0.3 and no other code changes.

I took the liberty of creating a `val json4sVersion` instead of having the version number separately in util-jackson and util-validator... this should help to keep them in sync in the future.
