### PR TITLE
Update scala versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.12.12, 2.13.6]
+        scala: [2.12.15, 2.13.6]
         java: ['1.8', '1.11']
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,10 @@ def jdk11GcJavaOptions: Seq[String] = {
   )
 }
 
+// Upgrading to a later version requires also upgrading sbt-scoverage, Scalatest, and
+// some modules like util-mock and util-test.
 val _scalaVersion = "2.13.6"
-val _crossScalaVersions = Seq("2.12.12", "2.13.6")
+val _crossScalaVersions = Seq("2.12.15", "2.13.6")
 
 val defaultScalaSettings = Seq(
   scalaVersion := _scalaVersion,
@@ -91,7 +93,7 @@ val defaultScalaSettings = Seq(
 )
 val defaultScala3EnabledSettings = Seq(
   scalaVersion := _scalaVersion,
-  crossScalaVersions := _crossScalaVersions ++ Seq("3.0.2-RC1")
+  crossScalaVersions := _crossScalaVersions ++ Seq("3.1.3")
 )
 
 // Our dependencies or compiler options may differ for both Scala 2 and 3. We branch here

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += Classpaths.sbtPluginReleases
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.31")

--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -54,7 +54,8 @@ class WeNeverCloseButWeDoNotCare extends WeNeverClose {
 }
 
 trait ErrorOnExitApp extends App {
-  override val defaultCloseGracePeriod: Duration = 5.seconds
+  // Prevent flaky test in CI due to TimeoutException with this generous timeout
+  override val defaultCloseGracePeriod: Duration = 30.seconds
 
   override def exitOnError(throwable: Throwable): Unit = {
     throw throwable


### PR DESCRIPTION
This is primarily to get away from the release candidate version of Scala 3. I also updated the other Scala versions for general maintenance.

edit: I missed PR #300 which already updates Scala 3 to a non-RC version, my apologies. I'll let you be the judge which PR to accept and will modify/rebase/close mine accordingly.

edit2: I wanted to add CI for Scala 3 as well but scoverage isn't quite there yet and some build adjustments are needed, so this will require a separate PR.

Cheers
~ Felix