### PR TITLE
support scala 3 build for util-tunable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ val defaultScalaSettings = Seq(
 )
 val defaultScala3EnabledSettings = Seq(
   scalaVersion := _scalaVersion,
-  crossScalaVersions := _crossScalaVersions ++ Seq("3.0.2")
+  crossScalaVersions := _crossScalaVersions ++ Seq("3.2.2")
 )
 
 // Our dependencies or compiler options may differ for both Scala 2 and 3. We branch here
@@ -678,7 +678,7 @@ lazy val utilTunable = Project(
   id = "util-tunable",
   base = file("util-tunable")
 ).settings(
-    sharedSettings
+    sharedScala3EnabledSettings
   ).settings(
     name := "util-tunable",
     libraryDependencies ++= Seq(

--- a/util-tunable/src/main/scala/com/twitter/util/tunable/TunableMap.scala
+++ b/util-tunable/src/main/scala/com/twitter/util/tunable/TunableMap.scala
@@ -5,6 +5,7 @@ import java.util.function.BiFunction
 import scala.annotation.varargs
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
 
 /**
  * A Map that can be used to access [[Tunable]]s using [[TunableMap.Key]]s.
@@ -133,7 +134,7 @@ object TunableMap {
   }
 
   object Key {
-    def apply[T](id: String)(implicit m: Manifest[T]): Key[T] =
+    def apply[T](id: String)(implicit m: ClassTag[T]): Key[T] =
       Key[T](id, m.runtimeClass.asInstanceOf[Class[T]])
   }
 
@@ -199,7 +200,7 @@ object TunableMap {
      * Put a [[Tunable]] with id `id` and value `value` into the [[TunableMap]]. If the [[Tunable]]
      * for that `id` already exists, update the value to `value`.
      */
-    final def put[T](id: String, value: T)(implicit m: Manifest[T]): Key[T] =
+    final def put[T](id: String, value: T)(implicit m: ClassTag[T]): Key[T] =
       put[T](id, m.runtimeClass.asInstanceOf[Class[T]], value)
 
     /**


### PR DESCRIPTION
This PR builds on #304 so that should be merged before this one imo.

With the new Jackson version supporting Scala 3 directly, `util-tunable` was just a config change.

I'm not sure why `scala-collection-compat_3` was excluded from the Scala 3 settings. It was probably an attempt to solve the "conflicting version suffix" error from sbt. I moved it to the Scala 2 settings but I can also remove it if you prefer.