### PR TITLE
support scala 3 build for util-test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -650,12 +650,25 @@ lazy val utilTest = Project(
   id = "util-test",
   base = file("util-test")
 ).settings(
-    sharedSettings
+    sharedScala3EnabledSettings
   ).settings(
     name := "util-test",
-    libraryDependencies ++= Seq(
-      "org.mockito" % "mockito-all" % "1.10.19",
-      "org.scalatestplus" %% "mockito-1-10" % "3.1.0.0"
+    libraryDependencies ++= (
+      if (scalaVersion.value.startsWith("2"))
+        Seq(
+          "org.mockito" % "mockito-all" % "1.10.19",
+          "org.scalatestplus" %% "mockito-1-10" % "3.1.0.0"
+        )
+      else
+        Seq(
+          // We keep this ancient version for now as it's unclear how much source incompatibility a jump to 3.4.x would
+          // cause to consumers of this module.
+          // If we run into compatibility issues with new versions of scalatest-mockito we will have to upgrade to
+          // mockito-core 3.4.x for Scala 2 and 3.
+          "org.mockito" % "mockito-all" % "1.10.19",
+          "org.scalatest" %% "scalatest" % "3.2.9",
+          "org.scalatestplus" %% "mockito-3-4" % "3.2.9.0"
+        )
     )
   ).dependsOn(utilCore, utilLogging, utilStats)
 


### PR DESCRIPTION
This PR builds on https://github.com/twitter/util/pull/304 so that should be merged before this one imo.

There is no Scala 3 compatible version for `"org.scalatestplus" %% "mockito-1-10"`, so I had to use `"org.scalatestplus" %% "mockito-3-4" % "3.2.9.0"`. This means I upgraded Scalatest to `3.2.9` and Mockito to `3.4.x`. This doesn't really break any code in `util-test` but consumers of `util-test` (e.g. `finagle` or `twitter-server`) might also have to upgrade those test dependencies.

Since Scala 3 requires Scalatest `3.2.x` and Mockito `1.10.x` is ancient at this point, I find this acceptable.

The second point is that I couldn't find a direct replacement for `org.mockito.exceptions.Reporter` from Mockito `1.10.x`. Since it was only used to throw a predefined exception, I inlined the error message. I hope this is acceptable.