### PR TITLE
build: Add Scala 3 to CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.12.12, 2.13.6]
+        scala: [2.12.12, 2.13.6, 3.0.2]
         java: ['1.8', '1.11']
     runs-on: ubuntu-latest
     steps:
@@ -52,4 +52,4 @@ jobs:
             find ~/.sbt         -name "*.lock"               -delete
           fi
       - name: test
-        run: ${{ format('./sbt ++{0} clean test', matrix.scala) }}
+        run: ${{ format('./sbt "++{0} -v clean; ++{0} test"', matrix.scala) }}


### PR DESCRIPTION
Several people have worked on Scala 3 support of various modules, which is great.

Scala 3 support currently isn't part of CI, which means it is only validated locally by the person currently working on it. This causes already working cross-builds to break by accident (e.g. when updating versions).

To avoid this and make working on Scala 3 more efficient I'm trying to setup at least basic CI for it.

Coverage is currently not really working with Scala 3.0.2, so I'm trying to ignore it for Scala 3 only.