### PR TITLE
Downgrade scoverage plugin due to build failure

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += Classpaths.sbtPluginReleases
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")


### PR DESCRIPTION
I just spotted https://github.com/twitter/util/pull/307 - either this or that work.

https://pipelines.actions.githubusercontent.com/serviceHosts/a9380272-989d-434a-87fd-c3400fd73bc6/_apis/pipelines/1/runs/319/signedlogcontent/4?urlExpires=2022-07-28T14%3A36%3A31.9786687Z&urlSigningMethod=HMACV1&urlSignature=6gPuwgWrdKksNYDd2hD%2B0bduviMptquIHcOz67xAdt0%3D

```
2022-07-27T03:25:56.2982328Z [error] (util-test / update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
2022-07-27T03:25:56.2984094Z [error] 
2022-07-27T03:25:56.2985860Z [error] 	* org.scala-lang.modules:scala-xml_2.13:2.1.0 (early-semver) is selected over 1.2.0
2022-07-27T03:25:56.2987807Z [error] 	    +- org.scoverage:scalac-scoverage-reporter_2.13:2.0.0 (depends on 2.1.0)
2022-07-27T03:25:56.2989942Z [error] 	    +- org.scalatest:scalatest_2.13:3.1.0                 (depends on 1.2.0)
2022-07-27T03:25:56.2992513Z [error] 
```