### PR TITLE
Attempt to fix flaky util-app test in GitHub CI

### DIFF
--- a/util-app/src/test/scala/com/twitter/app/AppTest.scala
+++ b/util-app/src/test/scala/com/twitter/app/AppTest.scala
@@ -54,7 +54,7 @@ class WeNeverCloseButWeDoNotCare extends WeNeverClose {
 }
 
 trait ErrorOnExitApp extends App {
-  override val defaultCloseGracePeriod: Duration = 10.seconds
+  override val defaultCloseGracePeriod: Duration = 30.seconds
 
   override def exitOnError(throwable: Throwable): Unit = {
     throw throwable
@@ -397,6 +397,10 @@ class AppTest extends AnyFunSuite {
   }
 
   test("App: exit functions properly capture mix of non-fatal and fatal exceptions") {
+    // This test case is known to be flaky on GitHub CI because it throws a `TimeoutException` before the expected
+    // `InterruptedException` is thrown.
+    // I suspect this is due to CI has limited CPU resources compared to local development while running lots of test
+    // suites in parallel.
     val app = new ErrorOnExitApp {
       def main(): Unit = {
         onExit {


### PR DESCRIPTION
As you can see in many PRs (e.g. #308) there is often one of the different build matrix cases red. As far as I can see it's always the same flaky test case in `AppTest` (in `util-app`).

I tried many things but couldn't reproduce the timeout locally. As an attempt to fight the failures in CI, I'm increasing the timeout for the grace period and also add retries to the test case.

I understand that this is mostly a band aid and not a great solution, so if you don't like it please let me know how we should tackle this instead.

Cheers
~ Felix