### PR TITLE
add pvp versionScheme to project POMs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -254,6 +254,8 @@ def scalatestScalacheckVersionedDep(scalaVersion: String) = {
   }
 }
 
+ThisBuild / versionScheme := Some("pvp")
+
 lazy val util = Project(
   id = "util",
   base = file(".")


### PR DESCRIPTION
[PVP is described by sbt](https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme) as a version scheme in which "X.Y are treated as [the] major version," which I think accurately describes the version scheme of this library. Adding this setting to a library's POM will help sbt manage evictions and transitive dependencies, and should help avoid binary incompatibilities. (See ["Preventing Version Conflicts with versionScheme"](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html) and [the sbt documentation](https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme) for more details.)

If this change is accepted, I'm happy to make similar PRs to finagle and scrooge.