### PR TITLE
Expose underlying slf4j Logger

### DIFF
--- a/util-slf4j-api/src/main/scala/com/twitter/util/logging/Logger.scala
+++ b/util-slf4j-api/src/main/scala/com/twitter/util/logging/Logger.scala
@@ -208,7 +208,7 @@ object Logger {
  * }}}
  */
 @SerialVersionUID(1L)
-final class Logger private (underlying: slf4j.Logger) extends Serializable {
+final class Logger private (val underlying: slf4j.Logger) extends Serializable {
 
   /* NOTE: we do not expose the non-varargs variations as we are unable to
      correctly call them from Scala, i.e.,


### PR DESCRIPTION
Updates `util.Logger` to expose the underlying `slf4j.Logger` instance. This is beneficial for those with projects with several SLF4J Loggers, and follows the pattern in the [scala-logging project](https://github.com/lightbend-labs/scala-logging/blob/main/src/main/scala/com/typesafe/scalalogging/Logger.scala#L82). 