### PR TITLE
fix: fromSeq stack-safe

### DIFF
--- a/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
+++ b/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
@@ -647,7 +647,7 @@ object AsyncStream {
   def fromSeq[A](seq: Seq[A]): AsyncStream[A] = seq match {
     case Nil => empty
     case _ if SeqUtil.hasKnownSize(seq) && seq.tail.isEmpty => of(seq.head)
-    case _ => seq.head +:: fromSeq(seq.tail)
+    case _ => of(seq.head).flatMap(_ +:: fromSeq(seq.tail))
   }
 
   /**

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -752,16 +752,15 @@ class AsyncStreamTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
     test(s"$impl: fromSeq is stack-safe") {
       val n = 100000
       val longSeq = (0 until n).toSeq
-      val result = AsyncStream.fromSeq(longSeq)
-        .filter(i => i > 10)
-        .filter(i => i > 100)
-        .filter(i => i > 1000)
-        .filter(i => i > 10000)
-        .filter(i => i > 100000)
+      val stream = AsyncStream.fromSeq(longSeq)
+        .filter(_ > 10)
+        .filter(_ > 100)
+        .filter(_ > 1000)
+        .filter(_ > 10000)
+        .filter(_ > 100000)
         .take(Int.MaxValue)
-        .toSeq
 
-      assert(Await.result(result.liftToTry).isReturn)
+      assert(Await.result(stream.toSeq.liftToTry).isReturn)
     }
   }
 

--- a/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
+++ b/util-core/src/test/scala/com/twitter/concurrent/AsyncStreamTest.scala
@@ -748,6 +748,21 @@ class AsyncStreamTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 
       assert(Await.result(stream.toSeq()) == Seq(n))
     }
+
+    test(s"$impl: fromSeq is stack-safe") {
+      val n = 100000
+      val longSeq = (0 until n).toSeq
+      val result = AsyncStream.fromSeq(longSeq)
+        .filter(i => i > 10)
+        .filter(i => i > 100)
+        .filter(i => i > 1000)
+        .filter(i => i > 10000)
+        .filter(i => i > 100000)
+        .take(Int.MaxValue)
+        .toSeq
+
+      assert(Await.result(result.liftToTry).isReturn)
+    }
   }
 
 }


### PR DESCRIPTION
I encountered a StackOverflowError while trying to get an AsyncStream from a long sequence using fromSeq, along with filter and take operations.

```
[info]   java.lang.StackOverflowError:
[info]   at com.twitter.concurrent.AsyncStream.$anonfun$filter$2(AsyncStream.scala:250)
[info]   at com.twitter.util.Return.map(Try.scala:308)
[info]   at com.twitter.util.Future.$anonfun$map$1(Future.scala:1939)
[info]   at com.twitter.util.ConstFuture.transformTry(ConstFuture.scala:47)
[info]   at com.twitter.util.Future.map(Future.scala:1939)
[info]   at com.twitter.concurrent.AsyncStream.filter(AsyncStream.scala:249)
[info]   at com.twitter.concurrent.AsyncStream.$anonfun$filter$4(AsyncStream.scala:253)
[info]   at com.twitter.util.Return.map(Try.scala:308)
[info]   at com.twitter.util.Future.$anonfun$map$1(Future.scala:1939)
```

I wrote a unit test that reproduces this behavior.