### PR TITLE
Add java.util.function.Function and Consumer interop overloads in Fun…

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Function.scala
+++ b/util-core/src/main/scala/com/twitter/util/Function.scala
@@ -76,6 +76,30 @@ object Function {
   }
 
   /**
+   * Creates a [[Function]] of `T` to `R` from a `java.util.function.Function`.
+   *
+   * Allows for better interop with Scala from Java 8 using the standard JDK
+   * functional interfaces.
+   *
+   * For example:
+   * {{{
+   * import com.twitter.util.Future;
+   * import static com.twitter.util.Function.func;
+   * import java.util.function.Function;
+   *
+   * Function<String, Integer> f = String::length;
+   * Future<String> fs = Future.value("example");
+   * Future<Integer> fi = fs.map(func(f));
+   * }}}
+   *
+   * @see [[func]] if you have a [[com.twitter.function.JavaFunction]].
+   * @see [[exfunc]] if your function throws checked exceptions.
+   */
+  def func[T, R](f: juf.Function[T, R]): Function[T, R] = new Function[T, R] {
+    def apply(value: T): R = f.apply(value)
+  }
+
+  /**
    * Creates a [[Function0]] of type-`T` from a `java.util.function.JavaSupplier`.
    *
    * Allows for better interop with Scala from Java 8 using lambdas.
@@ -120,6 +144,31 @@ object Function {
    */
   def cons[T](f: JavaConsumer[T]): Function[T, Unit] = new Function[T, Unit] {
     def apply(value: T): Unit = f(value)
+  }
+
+  /**
+   * Creates a [[Function]] of `T` to `Unit` from a `java.util.function.Consumer`.
+   *
+   * Allows for better interop with Scala from Java 8 using the standard JDK
+   * functional interfaces.
+   *
+   * For example:
+   * {{{
+   * import com.twitter.util.Future;
+   * import static com.twitter.util.Function.cons;
+   * import java.util.function.Consumer;
+   *
+   * Consumer<String> c = System.out::println;
+   * Future<String> fs = Future.value("example");
+   * Future<String> f2 = fs.onSuccess(cons(c));
+   * }}}
+   *
+   * @see [[excons]] if your function throws checked exceptions.
+   * @see [[func]] if you have a function which returns a type, `R`.
+   * @see [[func0]] if you have a function which takes no input.
+   */
+  def cons[T](f: juf.Consumer[T]): Function[T, Unit] = new Function[T, Unit] {
+    def apply(value: T): Unit = f.accept(value)
   }
 
   /**

--- a/util-core/src/test/java/com/twitter/util/FunctionCompilationTest.java
+++ b/util-core/src/test/java/com/twitter/util/FunctionCompilationTest.java
@@ -10,6 +10,8 @@ import static com.twitter.util.Function.func0;
 import static com.twitter.util.Function.excons;
 import static com.twitter.util.Function.exfunc;
 import static com.twitter.util.Function.exfunc0;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 
 public class FunctionCompilationTest {
@@ -76,6 +78,42 @@ public class FunctionCompilationTest {
     Function<String, BoxedUnit> fun =
       excons(value -> { throw new Exception("Expected"); });
     fun.apply("test");
+  }
+
+  @Test
+  public void testFuncFromJavaUtilFunction() {
+    Function<String, Integer> f = new Function<String, Integer>() {
+      @Override
+      public Integer apply(String s) {
+        return s.length();
+      }
+    };
+    com.twitter.util.Function<String, Integer> fun = func(f);
+    Assert.assertEquals(4, fun.apply("test").intValue());
+  }
+
+  @Test
+  public void testFuncFromJavaUtilFunctionLambda() {
+    com.twitter.util.Function<String, Integer> fun = func((String s) -> s.length());
+    Assert.assertEquals(4, fun.apply("test").intValue());
+  }
+
+  @Test
+  public void testConsFromJavaUtilConsumer() {
+    Consumer<String> c = new Consumer<String>() {
+      @Override
+      public void accept(String s) {
+        // no-op
+      }
+    };
+    com.twitter.util.Function<String, BoxedUnit> fun = cons(c);
+    Assert.assertEquals(BoxedUnit.UNIT, fun.apply("test"));
+  }
+
+  @Test
+  public void testConsFromJavaUtilConsumerLambda() {
+    com.twitter.util.Function<String, BoxedUnit> fun = cons((String s) -> {});
+    Assert.assertEquals(BoxedUnit.UNIT, fun.apply("test"));
   }
 
 }


### PR DESCRIPTION
…ction.scala

Add func[T, R](f: juf.Function[T, R]) and cons[T](f: juf.Consumer[T]) overloads to com.twitter.util.Function object, following the existing pattern of func0 for java.util.function.Supplier. This improves Java 8+ interop by allowing standard JDK functional interfaces to be converted to Twitter's Function types.

Add corresponding tests in FunctionCompilationTest.java for both new overloads covering anonymous class and lambda usage.